### PR TITLE
Implement `toString` cheatcode

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2045,6 +2045,13 @@ cheatActions = Map.fromList
   , action "assertGt(int256,int256)"   $ assertSGt (AbiIntType 256)
   , action "assertGe(uint256,uint256)" $ assertGe (AbiUIntType 256)
   , action "assertGe(int256,int256)"   $ assertSGe (AbiIntType 256)
+  --
+  , action "toString(address)" $ toStringCheat AbiAddressType
+  , action "toString(bool)"    $ toStringCheat AbiBoolType
+  , action "toString(uint256)" $ toStringCheat (AbiUIntType 256)
+  , action "toString(int256)"  $ toStringCheat (AbiIntType 256)
+  , action "toString(bytes32)" $ toStringCheat (AbiBytesType 32)
+  , action "toString(bytes)"   $ toStringCheat AbiBytesDynamicType
   ]
   where
     action s f = (abiKeccak s, f (abiKeccak s))
@@ -2109,6 +2116,10 @@ cheatActions = Map.fromList
     assertSLe =   genAssert (<=) (\a b -> Expr.iszero $ Expr.sgt a b) ">" "assertLe"
     assertGe =    genAssert (>=) Expr.geq "<" "assertGe"
     assertSGe =   genAssert (>=) (\a b -> Expr.iszero $ Expr.slt a b) "<" "assertGe"
+    toStringCheat abitype sig input = do
+      case decodeBuf [abitype] input of
+        CAbi [val] -> frameReturn $ AbiTuple $ V.fromList [AbiString $ Char8.pack $ show val]
+        _ -> vmError (BadCheatCode ("toString parameter decoding failed for " <> show abitype) sig)
 
 -- * General call implementation ("delegateCall")
 -- note that the continuation is ignored in the precompile case

--- a/test/contracts/pass/cheatCodes.sol
+++ b/test/contracts/pass/cheatCodes.sol
@@ -31,6 +31,12 @@ interface Hevm {
     function envString(string calldata key, string calldata delimiter) external returns (string[] memory values);
     function envBytes(bytes calldata key) external returns (bytes memory value);
     function envBytes(bytes calldata key, bytes calldata delimiter) external returns (bytes[] memory values);
+    function toString(address value) external returns (string memory);
+    function toString(bool value) external returns (string memory);
+    function toString(uint256 value) external returns (string memory);
+    function toString(int256 value) external returns (string memory);
+    function toString(bytes32 value) external returns (string memory);
+    function toString(bytes memory value) external returns (string memory);
 }
 
 contract HasStorage {
@@ -470,5 +476,75 @@ contract CheatCodes is Test {
     function prove_label_works() public {
         hevm.label(address(this), "label");
         assert(true);
+    }
+
+    function prove_toString_address() public {
+        address testAddr = address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+        string memory result = hevm.toString(testAddr);
+        assertEq(result, "0x7109709ECfa91a80626fF3989D68f67F5b1DD12D");
+
+        address zeroAddr = address(0);
+        string memory zeroResult = hevm.toString(zeroAddr);
+        assertEq(zeroResult, "0x0000000000000000000000000000000000000000");
+    }
+
+    function prove_toString_bool() public {
+        string memory trueResult = hevm.toString(true);
+        assertEq(trueResult, "true");
+
+        string memory falseResult = hevm.toString(false);
+        assertEq(falseResult, "false");
+    }
+
+    function prove_toString_uint256() public {
+        string memory zeroResult = hevm.toString(uint256(0));
+        assertEq(zeroResult, "0");
+
+        string memory smallResult = hevm.toString(uint256(123));
+        assertEq(smallResult, "123");
+
+        string memory maxResult = hevm.toString(type(uint256).max);
+        assertEq(maxResult, "115792089237316195423570985008687907853269984665640564039457584007913129639935");
+    }
+
+    function prove_toString_int256() public {
+        string memory zeroResult = hevm.toString(int256(0));
+        assertEq(zeroResult, "0");
+
+        string memory positiveResult = hevm.toString(int256(123));
+        assertEq(positiveResult, "123");
+
+        string memory negativeResult = hevm.toString(int256(-123));
+        assertEq(negativeResult, "-123");
+
+        string memory minResult = hevm.toString(type(int256).min);
+        assertEq(minResult, "-57896044618658097711785492504343953926634992332820282019728792003956564819968");
+
+        string memory maxResult = hevm.toString(type(int256).max);
+        assertEq(maxResult, "57896044618658097711785492504343953926634992332820282019728792003956564819967");
+    }
+
+    function prove_toString_bytes32() public {
+        bytes32 testBytes = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D000000000000000000000000;
+        string memory result = hevm.toString(testBytes);
+        assertEq(result, "0x7109709ecfa91a80626ff3989d68f67f5b1dd12d000000000000000000000000");
+
+        bytes32 zeroBytes = bytes32(0);
+        string memory zeroResult = hevm.toString(zeroBytes);
+        assertEq(zeroResult, "0x0000000000000000000000000000000000000000000000000000000000000000");
+    }
+
+    function prove_toString_bytes() public {
+        bytes memory testBytes = hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D";
+        string memory result = hevm.toString(testBytes);
+        assertEq(result, "0x7109709ecfa91a80626ff3989d68f67f5b1dd12d");
+
+        bytes memory emptyBytes = "";
+        string memory emptyResult = hevm.toString(emptyBytes);
+        assertEq(emptyResult, "0x");
+
+        bytes memory shortBytes = hex"acab";
+        string memory shortResult = hevm.toString(shortBytes);
+        assertEq(shortResult, "0xacab");
     }
 }


### PR DESCRIPTION
## Description

This implements the `toString` cheatcode. Reference: https://getfoundry.sh/reference/cheatcodes/to-string.html

## Checklist

- [X] tested locally
- [X] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
