### PR TITLE
Revert instead of crash when a missing cheat code is used in concrete mode

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1794,7 +1794,7 @@ cheat gas (inOffset, inSize) (outOffset, outSize) xs = do
       case Map.lookup abi' cheatActions of
         Nothing -> do
           vm <- get
-          partial $ CheatCodeMissing vm.state.pc abi'
+          caseVMType (partial $ CheatCodeMissing vm.state.pc abi') (finishFrame $ FrameReverted $ ConcreteBuf $ "Unknown cheat code") 
         Just action -> action input
 
 type CheatAction t s = Expr Buf -> EVM t s ()
@@ -3116,6 +3116,8 @@ instance VMOps Symbolic where
           Lit v -> continue $ Just v
           _ -> internalError "runAllPaths can only get concrete values here"
 
+  caseVMType s _ = s
+
 instance VMOps Concrete where
   burn' n continue = do
     available <- use (#state % #gas)
@@ -3244,6 +3246,7 @@ instance VMOps Concrete where
   partial _ = internalError "won't happen during concrete exec"
   branch _ (forceLit -> cond) continue = continue (cond > 0)
   manySolutions _ _ _ = internalError "SMT solver should never be needed in concrete mode"
+  caseVMType _ c = c
 
 -- Create symbolic VM from concrete VM
 symbolify :: VM Concrete s -> VM Symbolic s

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -888,6 +888,7 @@ class VMOps (t :: VMType) where
   partial :: PartialExec -> EVM t s ()
   branch :: Maybe Int -> Expr EWord -> (Bool -> EVM t s ()) -> EVM t s ()
   manySolutions :: Maybe Int -> Expr EWord -> Int -> (Maybe W256 -> EVM t s ()) -> EVM t s ()
+  caseVMType :: EVM Symbolic s () -> EVM Concrete s () -> EVM t s ()
 
 -- Bytecode Representations ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

This small change force a revert in concrete mode instead of crashing (after calling `partial`) if an unknown cheat code is used. It preserves the same behavior if the VM is symbolic

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
