### PR TITLE
SMT: Small changes towards efficiency

### DIFF
--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -382,6 +382,7 @@ solverArgs solver threads timeout = case solver of
     , "--produce-models"
     , "--time-limit-per=" <> mkTimeout timeout
     , "--bv-solver=preprop"
+    , "--bv-output-format=16"
     ]
   Z3 ->
     [ "-st"


### PR DESCRIPTION
## Description

This PR contains two changes:

- Pass option to Bitwuzla so that it uses hexadecimal, instead of binary, format for constants
- Make `copySlice` helper of `exprToSMT` more efficient in case the offsets are concrete.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
