### PR TITLE
Fixing build after RPC merging due to unused variable

### DIFF
--- a/test/clitest.hs
+++ b/test/clitest.hs
@@ -246,3 +246,4 @@ main = do
           ["--rpc", "http://mock.mock", "--prefix", "test_attack_symbolic"
           , "--number", "10307563", "--mock-file", "test/contracts/fail/rpc-test-mock.json"]
         stdout `shouldContain` "[FAIL]"
+        stderr `shouldNotContain` "CallStack"


### PR DESCRIPTION
## Description
Sorry, I somehow overlooked this. Let's wait for the build to finish then I will merge :) Apparently the `stderr` was unused, oops.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
