### PR TITLE
This flake lock update is automatic, adding as a change

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -241,13 +241,13 @@
       "locked": {
         "lastModified": 1716280767,
         "narHash": "sha256-cvRFeJkiaYPA+SoboEZhvH5sHDmmcMNR62OoKuEOWRg=",
-        "owner": "ethereum",
+        "owner": "argotorg",
         "repo": "solidity",
         "rev": "8a97fa7a1db1ec509221ead6fea6802c684ee887",
         "type": "github"
       },
       "original": {
-        "owner": "ethereum",
+        "owner": "argotorg",
         "repo": "solidity",
         "rev": "8a97fa7a1db1ec509221ead6fea6802c684ee887",
         "type": "github"


### PR DESCRIPTION
## Description
This flake lock update is automatic by nix if you re-run `nix develop .`. I am adding to a PR.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
