### PR TITLE
Update symbolic benchmark runner to use Bitwuzla

### DIFF
--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -105,8 +105,9 @@ mkbench :: IO ByteString -> String -> Integer -> [Natural] -> Benchmark
 mkbench c name iters counts = localOption WallTime $ env c (bgroup name . bmarks)
   where
     bmarks c' = concat $ [
-       [ bench ("cvc5-" <> show i) $ nfIO $ runApp $ findPanics CVC5 i iters c'
-       , bench ("z3-" <> show i) $ nfIO $ runApp $ findPanics Z3 i iters c'
+       [ bench ("bitwuzla-" <> show i) $ nfIO $ runApp $ findPanics Bitwuzla i iters c'
+      --  , bench ("z3-" <> show i) $ nfIO $ runApp $ findPanics Z3 i iters c'
+      --  , bench ("cvc5-" <> show i) $ nfIO $ runApp $ findPanics CVC5 i iters c'
        ]
        | i <- counts
      ]


### PR DESCRIPTION
After recent changes, we start to get some reasonable numbers in the symbolic execution performance benchmarks.

On my laptop these are the current numbers (note that these are rough):
- erc20: ~3.5 seconds
- vat: ~5 minutes
- deposit: NA (still allocating too much memory during exploration)
- uniV2: ~2.5 minutes
- blockchain tests: ~26 seconds

These are using Bitwuzla as the SMT solver.
There is still a lot of room for improvement, but it's a good start at the moment.
