### PR TITLE
Expr: Fix maxLitSigned

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -44,7 +44,7 @@ maxLitSigned :: W256
 maxLitSigned = 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 minLitSigned :: W256
-minLitSigned = 0x1000000000000000000000000000000000000000000000000000000000000000
+minLitSigned = 0x8000000000000000000000000000000000000000000000000000000000000000
 
 -- ** Stack Ops ** ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
The maximum signed value needs to start with 8 in hex, so that the most significant byte is `1000`. If it starts with `1`, the byte would be `0001`. This would be a positive number.
Moreover, the smallest value should be the largest value plus one. And the largest signed value is
`0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
