### PR TITLE
Fix GHC 9.10 warnings

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -218,7 +218,6 @@ executable hevm
     witch,
     unliftio-core,
     split,
-    wreq,
 
 --- Test Helpers ---
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -3,7 +3,7 @@
 
 module EVM where
 
-import Prelude hiding (exponent)
+import Prelude hiding (exponent, Foldable(..))
 
 import Optics.Core
 import Optics.State
@@ -40,7 +40,7 @@ import Data.ByteString.Char8 qualified as Char8
 import Data.DoubleWord (Int256, Word256)
 import Data.Either (partitionEithers)
 import Data.Either.Extra (maybeToEither)
-import Data.Foldable (toList)
+import Data.Foldable (toList, Foldable(..))
 import Data.List (find, isPrefixOf)
 import Data.List.Split (splitOn)
 import Data.Map.Strict (Map)
@@ -2811,7 +2811,7 @@ mkOpIxMap (RuntimeCode (ConcreteRuntimeCode ops)) =
 
 mkOpIxMap (RuntimeCode (SymbolicRuntimeCode ops))
   = VS.create $ VS.Mutable.new (length ops) >>= \v ->
-      let (_, _, _, m) = foldl (go v) (0, 0, 0, pure ()) (stripBytecodeMetadataSym $ V.toList ops)
+      let (_, _, _, m) = foldl' (go v) (0, 0, 0, pure ()) (stripBytecodeMetadataSym $ V.toList ops)
       in m >> pure v
       where
         go v (0, !i, !j, !m) x = case maybeLitByteSimp x of

--- a/src/EVM/ABI.hs
+++ b/src/EVM/ABI.hs
@@ -59,6 +59,8 @@ module EVM.ABI
   , showAlter
   ) where
 
+import Prelude hiding (Foldable(..))
+
 import EVM.Expr (readWord, isLitWord)
 import EVM.Types
 import EVM.Expr (maybeLitWordSimp)
@@ -76,13 +78,14 @@ import Data.ByteString.Lazy qualified as BSLazy
 import Data.Char (isHexDigit)
 import Data.Data (Data)
 import Data.DoubleWord (Word256, Int256, signedWord)
+import Data.Foldable (Foldable(..))
 import Data.Functor (($>))
 import Data.List (intercalate)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding (encodeUtf8)
-import Data.Vector (Vector, toList)
+import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import Data.Word (Word32)
 import GHC.Generics (Generic)
@@ -391,7 +394,7 @@ typeWithArraySuffix v = do
     parseSize t "" = AbiArrayDynamicType t
     parseSize t s  = AbiArrayType (read s) t
 
-  pure (foldl parseSize base sizes)
+  pure (foldl' parseSize base sizes)
 
 basicType :: Vector AbiType -> P.Parsec () Text AbiType
 basicType v =

--- a/src/EVM/Facts.hs
+++ b/src/EVM/Facts.hs
@@ -29,6 +29,8 @@ module EVM.Facts
   , fileToFact
   ) where
 
+import Prelude hiding (Foldable(..))
+
 import EVM          (bytecode, initialContract, loadContract)
 import EVM.Expr     (writeStorage)
 import EVM.Types
@@ -42,6 +44,7 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Base16 qualified as BS16
 import Data.ByteString qualified as BS
 import Data.ByteString.Char8 qualified as Char8
+import Data.Foldable (Foldable(..))
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
@@ -210,13 +213,13 @@ instance Ord Fact where
 apply :: VM s -> Set Fact -> VM s
 apply =
   -- The set's ordering is relevant; see `apply1`.
-  foldl apply1
+  foldl' apply1
 --
 -- Applies a set of facts to a VM.
 applyCache :: VM s -> Set Fact -> VM s
 applyCache =
   -- The set's ordering is relevant; see `apply1`.
-  foldl apply2
+  foldl' apply2
 
 factToFile :: Fact -> File
 factToFile fact = case fact of

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -15,6 +15,8 @@ module EVM.Fetch
   , addFetchCache
   ) where
 
+import Prelude hiding (Foldable(..))
+
 import EVM (initialContract, unknownContract)
 import EVM.ABI
 import EVM.FeeSchedule (feeSchedule)
@@ -34,9 +36,9 @@ import Data.ByteString qualified as BS
 import Data.Text (Text, unpack, pack)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
+import Data.Foldable (Foldable(..))
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, isJust, fromJust)
-import Data.List (foldl')
 import Data.Vector qualified as RegularVector
 import Network.Wreq
 import Network.Wreq.Session qualified as NetSession

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -3,6 +3,8 @@
 
 module EVM.SymExec where
 
+import Prelude hiding (Foldable(..))
+
 import Control.Arrow ((>>>))
 import Control.Concurrent.Async (concurrently, mapConcurrently)
 import Control.Concurrent.Spawn (parMapIO, pool)
@@ -15,7 +17,8 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.Containers.ListUtils (nubOrd)
 import Data.DoubleWord (Word256)
-import Data.List (foldl', sortBy, sort)
+import Data.Foldable (Foldable(..))
+import Data.List (sortBy, sort)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Map.Strict (Map)
@@ -705,7 +708,7 @@ verify solvers fetcher opts preState maybepost = do
   pure $ verifyResults preState expr res
 
 verifyResults :: VM Symbolic RealWorld -> Expr End -> [(SMTResult, Expr End)] -> (Expr End, [VerifyResult])
-verifyResults preState expr cexs = if Prelude.null cexs then (expr, [Qed]) else (expr, fmap toVRes cexs)
+verifyResults preState expr cexs = if null cexs then (expr, [Qed]) else (expr, fmap toVRes cexs)
   where
     toVRes :: (SMTResult, Expr End) -> VerifyResult
     toVRes (res, leaf) = case res of

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -89,13 +89,13 @@ foldExpr f acc expr = acc <> (go expr)
       -- control flow
 
       e@(Success a _ c d) -> f e
-                          <> foldl (foldProp f) mempty a
+                          <> foldl' (foldProp f) mempty a
                           <> go c
                           <> foldl' (foldExpr f) mempty (Map.keys d)
                           <> foldl' (foldEContract f) mempty d
-      e@(Failure a _ (Revert c)) -> f e <> (foldl (foldProp f) mempty a) <> go c
-      e@(Failure a _ _) -> f e <> (foldl (foldProp f) mempty a)
-      e@(Partial a _ _) -> f e <> (foldl (foldProp f) mempty a)
+      e@(Failure a _ (Revert c)) -> f e <> (foldl' (foldProp f) mempty a) <> go c
+      e@(Failure a _ _) -> f e <> (foldl' (foldProp f) mempty a)
+      e@(Partial a _ _) -> f e <> (foldl' (foldProp f) mempty a)
       e@(ITE a b c) -> f e <> (go a) <> (go b) <> (go c)
 
       -- integers
@@ -168,7 +168,7 @@ foldExpr f acc expr = acc <> (go expr)
 
       -- logs
 
-      e@(LogEntry a b c) -> f e <> (go a) <> (go b) <> (foldl (<>) mempty (fmap f c))
+      e@(LogEntry a b c) -> f e <> (go a) <> (go b) <> (foldl' (<>) mempty (fmap f c))
 
       -- storage
 

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -4,12 +4,12 @@
 -}
 module EVM.Traversals where
 
-import Prelude hiding (LT, GT)
+import Prelude hiding (LT, GT, Foldable(..))
 
 import Control.Monad (forM, void)
 import Control.Monad.Identity (Identity(Identity), runIdentity)
+import Data.Foldable (Foldable(..))
 import Data.Map.Strict qualified as Map
-import Data.List (foldl')
 
 import EVM.Types
 

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -1505,7 +1505,7 @@ constructWord256 bytes
     w256m0 = word8sToWord64 (take 8 (drop 16 bytes))
     w256lo = word8sToWord64 (take 8 (drop 24 bytes))
     word8sToWord64 :: [Word8] -> Word64
-    word8sToWord64 = foldl (\acc byte -> (acc `shiftL` 8) .|. fromIntegral byte) 0
+    word8sToWord64 = foldl' (\acc byte -> (acc `shiftL` 8) .|. fromIntegral byte) 0
 
 
 -- Keccak hashing ----------------------------------------------------------------------------------

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -11,6 +11,8 @@
 
 module EVM.Types where
 
+import Prelude hiding (Foldable(..))
+
 import GHC.Stack (HasCallStack, prettyCallStack, callStack)
 import GHC.ByteOrder (targetByteOrder, ByteOrder(..))
 import Control.Arrow ((>>>))
@@ -25,7 +27,6 @@ import Data.Bits (Bits, FiniteBits, shiftR, shift, shiftL, (.&.), (.|.), toInteg
 import Data.Binary qualified as Binary
 import Data.ByteArray qualified as BA
 import Data.Char
-import Data.List (foldl')
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as BS16
@@ -38,6 +39,7 @@ import Data.Int (Int64)
 import Data.Word (Word8, Word32, Word64, byteSwap32, byteSwap64)
 import Data.DoubleWord
 import Data.DoubleWord.TH
+import Data.Foldable (Foldable(..))
 import Data.Map (Map)
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -2,6 +2,8 @@
 
 module EVM.UnitTest where
 
+import Prelude hiding (Foldable(..))
+
 import EVM
 import EVM.ABI
 import EVM.Solvers
@@ -20,7 +22,6 @@ import EVM.Stepper (Stepper)
 import EVM.Stepper qualified as Stepper
 import EVM.Tracing qualified as Tracing
 import EVM.Expr (maybeLitWordSimp)
-import Data.List (foldl')
 
 import Control.Monad (void, when, forM, forM_)
 import Control.Monad.ST (RealWorld, ST, stToIO)
@@ -34,7 +35,7 @@ import Data.ByteString.Char8 qualified as BS
 import Data.ByteString.Internal (c2w)
 import Data.ByteString.Lazy qualified as BSLazy
 import Data.Decimal (DecimalRaw(..))
-import Data.Foldable (toList)
+import Data.Foldable (Foldable(..), toList)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe


### PR DESCRIPTION
## Description

This fixes warnings that appear when building with GHC 9.10, due to `foldl'` now being available on prelude as well.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
