### PR TITLE
Fix missing information about concrete Keccak computations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,8 +100,7 @@ jobs:
           persist-credentials: false
       - uses: foundry-rs/foundry-toolchain@v1
         with:
-          # Pinning to a version in June 2024, so in case a build fails, our CI doesn't fail
-          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559
+          version: stable
       - run: |
           echo FOUNDRY_PATH="$(dirname "$(which forge)")" >> "$GITHUB_ENV"
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - We now extract more Keccak computations than before from the Props to assert
   more Keccak equalities.
+- Fixed false positive caused by loss of information about concrete 
+  Keccak computations.
 - Faster word256Bytes and word160Bytes functions to help concrete execution
   performance
 - RPC fetching was sometimes incorrect in case of writing to storage

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -115,7 +115,7 @@ declareIntermediates bufs stores = do
 assertProps :: Config -> [Prop] -> Err SMT2
 assertProps conf ps =
   if not conf.simp then assertPropsHelper False ps
-  else assertPropsHelper True (decompose . Expr.simplifyProps $ ps)
+  else assertPropsHelper True (decompose ps)
   where
     decompose :: [Prop] -> [Prop]
     decompose props = if conf.decomposeStorage && safeExprs && safeProps

--- a/test/contracts/pass/keccak.sol
+++ b/test/contracts/pass/keccak.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.20;
+
+contract KeccakTest {
+  bool public IS_TEST = true;
+  mapping(int24 => uint256) private tickBitmap;
+
+  int24[] initedTicks;
+
+  constructor() public {
+    initedTicks.push(1);
+  }
+
+  function prove_access(int24 tick) public view {
+    assert(tickBitmap[tick] == 0);
+  }
+}

--- a/test/test.hs
+++ b/test/test.hs
@@ -2049,6 +2049,9 @@ tests = testGroup "hevm"
     , test "Unwind" $ do
         let testFile = "test/contracts/pass/unwind.sol"
         runSolidityTest testFile ".*" >>= assertEqualM "test result" (True, True)
+    , test "Keccak" $ do
+        let testFile = "test/contracts/pass/keccak.sol"
+        runSolidityTest testFile "prove_access" >>= assertEqualM "test result" (True, True)
     ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do


### PR DESCRIPTION
Previously, we would lose information about concrete Keccak computations during simplification.
This information is then missing when we create constraints on the abstract Keccak computations in the program.

The suggested solution is to collect concrete Keccak computations and re-add them to the Props after simplification.

We also need to remove the call to simplification in `assertProps`. The propositions are simplified before (in `checkSatWithProps`) and also afterwards, in `assertPropsHelper`. We need to ensure that the concrete Keccak computations survive until they are collected in `assertPropsHelper`.

Fixes #819.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
