### PR TITLE
Summarize getter storage-copy loops as StorageCopySlice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controlled via `merge-max-budget`
 - Missing simplifications for Eq, Mod, SMod, XOR, SHL, SHR, and Or
 - A few more simplification rules around Eq, SHL/SHR, Sub+Add combos, and Xor
+- `readWord` disjointness rule for `WriteWord (Add (Lit c) X) …` with bounded `X`.
 
 ## Changed
 - Simplifier now rewrites `Mul(-1, x)` and `~x + 1` to `Sub(0, x)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing simplifications for Eq, Mod, SMod, XOR, SHL, SHR, and Or
 - A few more simplification rules around Eq, SHL/SHR, Sub+Add combos, and Xor
 - `readWord` disjointness rule for `WriteWord (Add (Lit c) X) …` with bounded `X`.
+- Summarize Solidity public-getter copy loops (`bytes`/`string`/dynamic
+  arrays) via a new `StorageCopySlice` IR node; disable with
+  `--no-skip-getter-loops`.
 
 ## Changed
+- Symbolic-size `CopySlice` / `StorageCopySlice` at the SMT layer now
+  demote to `Partial (SymbolicCopySliceSize …)` instead of `Error`.
 - Simplifier now rewrites `Mul(-1, x)` and `~x + 1` to `Sub(0, x)`
 - `AbiFunction` and `AbiBytes` parser is now more strict
 - We now check length of AbiArrayDynamic and don't crash in case it's too large

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -102,6 +102,7 @@ data CommonOptions = CommonOptions
   , cacheDir      ::Maybe String
   , earlyAbort    ::Bool
   , mergeMaxBudget :: Int
+  , skipGetterLoops :: Bool
   }
 
 commonOptions :: Parser CommonOptions
@@ -133,6 +134,7 @@ commonOptions = CommonOptions
   <*> (optional $ strOption $ long "cache-dir" <> help "Directory to save and load RPC cache")
   <*> (switch $  long "early-abort" <> help "Stop exploration immediately upon finding the first counterexample")
   <*> (option auto $ long "merge-max-budget" <> showDefault <> value 100 <> help "Max instructions for speculative merge exploration during path merging")
+  <*> (flag True False $ long "no-skip-getter-loops" <> help "Disable short-circuit of detected storage-to-memory copy loops (e.g. bytes/string getters). On by default.")
 
 data CommonExecOptions = CommonExecOptions
   { address       ::Maybe Addr
@@ -377,6 +379,7 @@ main = do
         , onlyDeployed = cOpts.onlyDeployed
         , earlyAbort = cOpts.earlyAbort
         , mergeMaxBudget = cOpts.mergeMaxBudget
+        , skipGetterLoops = cOpts.skipGetterLoops
         } }
 
 

--- a/doc/src/common-options.md
+++ b/doc/src/common-options.md
@@ -70,3 +70,24 @@ This is helpful to prevent the exploration from running for too long. Useful in
 scenarios where you use e.g. both symbolic execution and fuzzing, and don't
 want the symbolic execution to run for too long. It will often read to
 WARNING-s related to `Branches too deep at program counter`.
+
+## Short-circuit Solidity getter loops, ``--no-skip-getter-loops``
+
+Solidity compiles `bytes public foo` / `string public foo` (and similar
+dynamic-element public getters) into bytecode that iterates over storage
+slots one word at a time, copying each into memory.  Under symbolic
+execution with symbolic storage, this loop has no statically known bound
+and would unroll forever — capped only by `--max-iterations`, producing
+`Partial` paths.
+
+By default, hevm statically detects these SLOAD→MSTORE copy loops in
+the contract's bytecode and replaces them at runtime with a single
+`StorageCopySlice` summary node.  The loop is skipped entirely, and
+reads from the summarized buffer are resolved directly to the underlying
+`SLoad` expressions.  This eliminates the spurious `Partial` paths and
+lets exploration continue past the getter.
+
+The detection is conservative — only loops whose body is exactly a
+copy (no side effects, statically-known jumps, stack-neutral) are
+summarized.  Pass `--no-skip-getter-loops` to turn the optimization off
+(e.g. to compare results with and without the summary).

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -102,6 +102,7 @@ library
     EVM.Exec,
     EVM.Format,
     EVM.ConsoleLog,
+    EVM.GetterDetection,
     EVM.Fetch,
     EVM.FeeSchedule,
     EVM.Op,

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -14,6 +14,7 @@ import EVM.ABI
 import EVM.Expr (readStorage, concStoreContains, writeStorage, readByte, readWord, writeWord,
   writeByte, bufLength, indexWord, readBytes, copySlice, wordToAddr, maybeLitByteSimp, maybeLitWordSimp, maybeLitAddrSimp)
 import EVM.Expr qualified as Expr
+import EVM.GetterDetection (detectCopyLoops)
 import EVM.FeeSchedule (FeeSchedule (..))
 import EVM.FeeSchedule qualified as Fees (feeSchedule)
 import EVM.Merge qualified as Merge
@@ -284,11 +285,12 @@ unknownContract addr = Contract
   , opIxMap     = mempty
   , codeOps     = mempty
   , external    = False
+  , getterLoops = Map.empty
   }
 
 -- | Initialize an abstract contract with known code
 abstractContract :: ContractCode -> Expr EAddr -> Contract
-abstractContract code addr = Contract
+abstractContract code addr = let ops = mkCodeOps code in Contract
   { code        = code
   , storage     = AbstractStore addr Nothing
   , tStorage    = AbstractStore addr Nothing
@@ -297,8 +299,9 @@ abstractContract code addr = Contract
   , nonce       = if isCreation code then Just 1 else Just 0
   , codehash    = hashcode code
   , opIxMap     = mkOpIxMap code
-  , codeOps     = mkCodeOps code
+  , codeOps     = ops
   , external    = False
+  , getterLoops = detectCopyLoops ops
   }
 
 -- | Initialize an empty contract without code
@@ -307,7 +310,7 @@ emptyContract = initialContract (RuntimeCode (ConcreteRuntimeCode ""))
 
 -- | Initialize empty contract with given code
 initialContract :: ContractCode -> Contract
-initialContract code = Contract
+initialContract code = let ops = mkCodeOps code in Contract
   { code        = code
   , storage     = ConcreteStore mempty
   , tStorage    = ConcreteStore mempty
@@ -316,8 +319,9 @@ initialContract code = Contract
   , nonce       = if isCreation code then Just 1 else Just 0
   , codehash    = hashcode code
   , opIxMap     = mkOpIxMap code
-  , codeOps     = mkCodeOps code
+  , codeOps     = ops
   , external    = False
+  , getterLoops = detectCopyLoops ops
   }
 
 isCreation :: ContractCode -> Bool

--- a/src/EVM/CSE.hs
+++ b/src/EVM/CSE.hs
@@ -64,6 +64,16 @@ go = \case
           bs' = Map.insert e next s.bufs
         put $ s{count=next+1, bufs=bs'}
         pure $ GVar (BufVar next)
+  e@(StorageCopySlice {}) -> do
+    s <- get
+    case Map.lookup e s.bufs of
+      Just v -> pure $ GVar (BufVar v)
+      Nothing -> do
+        let
+          next = s.count
+          bs' = Map.insert e next s.bufs
+        put $ s{count=next+1, bufs=bs'}
+        pure $ GVar (BufVar next)
   -- storage
   e@(SStore {}) -> do
     s <- get

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -48,6 +48,7 @@ data Config = Config
   , onlyDeployed     :: Bool
   , earlyAbort       :: Bool
   , mergeMaxBudget   :: Int        -- ^ Max instructions for speculative merge exploration
+  , skipGetterLoops  :: Bool       -- ^ Short-circuit detected storage-to-memory copy loops
   }
   deriving (Show, Eq)
 
@@ -69,6 +70,7 @@ defaultConfig = Config
   , onlyDeployed = False
   , earlyAbort = False
   , mergeMaxBudget = 100
+  , skipGetterLoops = True
   }
 
 -- Write to the console

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -418,7 +418,7 @@ readBytes (Prelude.min 32 -> n) idx buf
 
 -- | Static upper bound on a word expression (unsigned, no wrap), or Nothing.
 upperBound :: Expr EWord -> Maybe W256
-upperBound a = \case
+upperBound e = case (simplifyNoLitToKeccak e) of
   Lit n         -> Just n
   And (Lit m) _ -> Just m
   Mod _ (Lit b)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -696,7 +696,7 @@ bufLengthEnv env useEnv buf = go (Lit 0) buf
     go l (CopySlice _ _ (Lit 0) _ dst) = go l dst
     go l (CopySlice _ dstOffset size _ dst) = go (EVM.Expr.max l (add dstOffset size)) dst
     go l (StorageCopySlice _ dstOff numWords _ dst) =
-      go (EVM.Expr.max l (add dstOff (mul numWords (Lit 32)))) dst
+      go (EVM.Expr.max l (add dstOff (mul (Lit 32) numWords))) dst
 
     go l (GVar (BufVar a)) | useEnv =
       case Map.lookup a env of

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -405,6 +405,18 @@ readByte i@(Lit x) buf@(CopySlice _ (Lit dstOffset) (Lit size) _ dst)
     then readByte i dst
     else ReadByte (Lit x) buf
 
+-- StorageCopySlice: byte before / after / inside the region
+readByte i@(Lit x) (StorageCopySlice _ (Lit dstOff) _ _ dst)
+  | x < dstOff = readByte i dst
+readByte i@(Lit x) (StorageCopySlice _ (Lit dstOff) (Lit numWords) _ dst)
+  | x >= dstOff + numWords * 32 = readByte i dst
+readByte (Lit x) (StorageCopySlice (Lit baseSlot) (Lit dstOff) (Lit numWords) store _dst)
+  | x >= dstOff, x < dstOff + numWords * 32
+  = let wordIdx  = Prelude.div (x - dstOff) 32
+        byteIdx  = Prelude.mod (x - dstOff) 32
+        slotVal  = SLoad (Lit (baseSlot + wordIdx)) store
+    in IndexWord (Lit byteIdx) slotVal
+
 -- fully abstract reads
 readByte i buf = ReadByte i buf
 
@@ -481,6 +493,7 @@ readWord idx b@(WriteWord idx' val buf)
     _ -> readWordFromBytes idx b
 readWord i@(Lit idx) (WriteByte (Lit idx') _ buf)
   | idx' < idx || (idx' >= idx + 32 && idx <= (maxBound :: W256) - 32) = readWord i buf
+
 -- reading a Word that is before the CopySlice destination region, so just read from dst
 -- We must ensure x+32 and dstOffset+size do not wrap past maxBound.
 -- When size is symbolic, we bound dstOffset to ensure no wrapping is possible.
@@ -510,6 +523,19 @@ readWord (Lit idx) b@(CopySlice (Lit srcOff) (Lit dstOff) (Lit size) src dst)
   | (idx - dstOff) >= size && (idx - dstOff) <= (maxBound :: W256) - 31 = readWord (Lit idx) dst
   -- the region we are trying to read partially overlaps the sliced region
   | otherwise = readWordFromBytes (Lit idx) b
+
+-- StorageCopySlice: aligned-inside / before / past / overlap fallback
+readWord (Lit x) (StorageCopySlice (Lit baseSlot) (Lit dstOff) (Lit numWords) store _dst)
+  | x >= dstOff
+  , x < dstOff + numWords * 32
+  , Prelude.mod (x - dstOff) 32 == 0
+  = SLoad (Lit (baseSlot + Prelude.div (x - dstOff) 32)) store
+readWord i@(Lit x) (StorageCopySlice _ (Lit dstOff) _ _ dst)
+  | x + 32 <= dstOff, x + 32 >= x = readWord i dst
+readWord i@(Lit x) (StorageCopySlice _ (Lit dstOff) (Lit numWords) _ dst)
+  | x >= dstOff + numWords * 32 = readWord i dst
+readWord i b@(StorageCopySlice {}) = readWordFromBytes i b
+
 readWord i b = readWordFromBytes i b
 
 -- Attempts to read a concrete word from a buffer by reading 32 individual bytes and joining them together
@@ -669,6 +695,8 @@ bufLengthEnv env useEnv buf = go (Lit 0) buf
     go l (WriteByte idx _ b) = go (EVM.Expr.max l (add idx (Lit 1))) b
     go l (CopySlice _ _ (Lit 0) _ dst) = go l dst
     go l (CopySlice _ dstOffset size _ dst) = go (EVM.Expr.max l (add dstOffset size)) dst
+    go l (StorageCopySlice _ dstOff numWords _ dst) =
+      go (EVM.Expr.max l (add dstOff (mul numWords (Lit 32)))) dst
 
     go l (GVar (BufVar a)) | useEnv =
       case Map.lookup a env of
@@ -694,6 +722,9 @@ minLength bufEnv = go 0
     go l (WriteWord _ _ b) = go l b
     go l (WriteByte _ _ b) = go l b
     go l (CopySlice _ _ _ _ b) = go l b
+    go l (StorageCopySlice _ (Lit dstOff) (Lit numWords) _ dst) =
+      go (Prelude.max (dstOff + numWords * 32) l) dst
+    go l (StorageCopySlice _ _ _ _ b) = go l b
     go l (GVar (BufVar a)) = do
       b <- Map.lookup a bufEnv
       go l b
@@ -1240,6 +1271,13 @@ simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
           | otherwise = orig
             where simplifiedBuf = BS.take (unsafeInto (n+sz)) buf
     go (CopySlice a b c d f) = copySlice a b c d f
+
+    -- zero-word StorageCopySlice is a no-op
+    go (StorageCopySlice _ _ (Lit 0) _ dst) = dst
+    -- single-word StorageCopySlice is just a WriteWord of the loaded slot
+    go (StorageCopySlice baseSlot dstOff (Lit 1) store dst)
+      = writeWord dstOff (SLoad baseSlot store) dst
+    go scs@(StorageCopySlice {}) = scs
 
     go (JoinBytes (LitByte a0)  (LitByte a1)  (LitByte a2)  (LitByte a3)
       (LitByte a4)  (LitByte a5)  (LitByte a6)  (LitByte a7)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -416,12 +416,62 @@ readBytes :: Int -> Expr EWord -> Expr Buf -> Expr EWord
 readBytes (Prelude.min 32 -> n) idx buf
   = joinBytes [readByte (add idx (Lit . unsafeInto $ i)) buf | i <- [0 .. n - 1]]
 
+-- | Static upper bound on a word expression (unsigned, no wrap), or Nothing.
+upperBound :: Expr EWord -> Maybe W256
+upperBound = \case
+  Lit n         -> Just n
+  And (Lit m) _ -> Just m
+  And _ (Lit m) -> Just m
+  Mod _ (Lit b)
+    | b == 0    -> Just 0
+    | otherwise -> Just (b - 1)
+  Div a (Lit b)
+    | b == 0    -> Just 0
+    | otherwise -> upperBound a >>= \ua -> Just (ua `Prelude.div` b)
+  Mul (Lit a) b -> mulBound a b
+  Mul a (Lit b) -> mulBound b a
+  Add (Lit a) b -> addBound a b
+  Add a (Lit b) -> addBound b a
+  SHR (Lit n) b
+    | n >= 256  -> Just 0
+    | otherwise -> upperBound b >>= \ub ->
+        Just (ub `shiftR` fromIntegral n)
+  _ -> Nothing
+  where
+    mulBound a b
+      | a == 0    = Just 0
+      | otherwise = upperBound b >>= \ub ->
+          if ub == 0 then Just 0
+          else if ub <= (maxBound :: W256) `Prelude.div` a then Just (a * ub)
+          else Nothing
+    addBound a b = upperBound b >>= \ub ->
+      if a <= (maxBound :: W256) - ub then Just (a + ub) else Nothing
+
+-- | True if the WriteWord at @wIdx@ is provably disjoint from the 32-byte
+--   read at @i@. Sound mod 2^256: requires both windows to fit below 2^256.
+writeDisjointFromReadWord :: W256 -> Expr EWord -> Bool
+writeDisjointFromReadWord i = \case
+  Add (Lit c) x
+    | Just ux <- upperBound x ->
+        let cI        = toInteger c
+            uxI       = toInteger ux
+            iI        = toInteger i
+            maxI      = toInteger (maxBound :: W256)
+            writeMaxI = cI + uxI + 31
+            readMaxI  = iI + 31
+        in readMaxI <= maxI
+           && writeMaxI <= maxI
+           && (cI >= iI + 32 || writeMaxI < iI)
+  _ -> False
+
 -- | Reads the word starting at idx from the given buf
 readWord :: Expr EWord -> Expr Buf -> Expr EWord
 readWord idx buf@(AbstractBuf _) = ReadWord idx buf
 readWord idx b@(WriteWord idx' val buf)
   -- the word we are trying to read exactly matches a WriteWord
   | idx == idx' = val
+  -- WriteWord provably disjoint via interval bounds (Add (Lit c) X, X bounded)
+  | Lit i <- idx, writeDisjointFromReadWord i idx' = readWord idx buf
   | otherwise = case (idx, idx') of
     (Lit i, Lit i') ->
       if i' - i >= 32 && i' - i <= (maxBound :: W256) - 31

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -418,10 +418,9 @@ readBytes (Prelude.min 32 -> n) idx buf
 
 -- | Static upper bound on a word expression (unsigned, no wrap), or Nothing.
 upperBound :: Expr EWord -> Maybe W256
-upperBound = \case
+upperBound a = \case
   Lit n         -> Just n
   And (Lit m) _ -> Just m
-  And _ (Lit m) -> Just m
   Mod _ (Lit b)
     | b == 0    -> Just 0
     | otherwise -> Just (b - 1)
@@ -429,9 +428,7 @@ upperBound = \case
     | b == 0    -> Just 0
     | otherwise -> upperBound a >>= \ua -> Just (ua `Prelude.div` b)
   Mul (Lit a) b -> mulBound a b
-  Mul a (Lit b) -> mulBound b a
   Add (Lit a) b -> addBound a b
-  Add a (Lit b) -> addBound b a
   SHR (Lit n) b
     | n >= 256  -> Just 0
     | otherwise -> upperBound b >>= \ub ->

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -525,6 +525,10 @@ formatPartial = \case
       , "program counter: " <> pack (show pc)]
     ]
 
+  SymbolicCopySliceSize what -> T.unlines
+    [ T.pack what <> " with a symbolically sized region survived to the SMT layer; encoding fell back to Partial."
+    ]
+
 
 formatPartialDetailed :: Maybe SrcLookup -> Map.Map (Expr EAddr) Contract -> PartialExec -> Text
 formatPartialDetailed srcLookupM contracts p =
@@ -536,6 +540,7 @@ formatPartialDetailed srcLookupM contracts p =
     CheatCodeMissing {..}      -> "Cheat code not recognized: " <> T.pack (show selector) <> toTxt addr pc
     PrecompileMissing {..}     -> "Precompile at address " <> pack (show preAddr) <> " does not exist, called from" <> toTxt addr pc
     BranchTooDeep {..}         -> "Branches too deep" <> toTxt addr pc
+    SymbolicCopySliceSize what -> T.pack what <> " with symbolic size cannot be SMT-encoded; surfaced as Partial."
 
 formatSomeExpr :: SomeExpr -> Text
 formatSomeExpr (SomeExpr e) = formatExpr $ Expr.simplify e
@@ -790,6 +795,19 @@ formatExpr = go
           , "size:      " <> formatExpr size
           , "src:"
           , indent 2 $ formatExpr src
+          , "dst:"
+          , indent 2 $ formatExpr dst
+          ]
+        , ")"
+        ]
+      StorageCopySlice baseSlot dstOff numWords store dst -> T.unlines
+        [ "(StorageCopySlice"
+        , indent 2 $ T.unlines
+          [ "baseSlot: " <> formatExpr baseSlot
+          , "dstOff:   " <> formatExpr dstOff
+          , "numWords: " <> formatExpr numWords
+          , "store:"
+          , indent 2 $ formatExpr store
           , "dst:"
           , indent 2 $ formatExpr dst
           ]

--- a/src/EVM/GetterDetection.hs
+++ b/src/EVM/GetterDetection.hs
@@ -1,0 +1,271 @@
+-- | Detect SLOAD->MSTORE copy loops in bytecode so the symbolic executor can
+-- short-circuit them via StorageCopySlice.
+module EVM.GetterDetection
+  ( detectCopyLoops
+  ) where
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Vector qualified as V
+
+import EVM.Types (CopyLoop(..), StorageLoopStackInfo(..), Op, GenericOp(..))
+import EVM.Expr (maybeLitWordSimp)
+
+-- | Scan op vector for copy loops, keyed by condJumpiPC.
+-- Pattern A: backward JUMPI (condition at bottom), exitBranch=False.
+-- Pattern B: backward JUMP + forward exit JUMPI, exitBranch=True.
+detectCopyLoops :: V.Vector (Int, Op) -> Map Int CopyLoop
+detectCopyLoops ops =
+  let jumpdests  = buildJumpdestSet ops
+      candidates = findBackwardJumps ops jumpdests
+      loops      = [loop | (p, q) <- candidates, Just loop <- [analyseBody ops p q]]
+  in Map.fromList [(l.condJumpiPC, l) | l <- loops]
+
+-- | All JUMPDEST PCs.
+buildJumpdestSet :: V.Vector (Int, Op) -> Set Int
+buildJumpdestSet ops = Set.fromList [pc | (pc, OpJumpdest) <- V.toList ops]
+
+-- | (target, jumpPC) pairs where a PUSH <Lit target> immediately precedes a
+-- JUMP/JUMPI that jumps backward (target < jumpPC) to a known JUMPDEST.
+findBackwardJumps :: V.Vector (Int, Op) -> Set Int -> [(Int, Int)]
+findBackwardJumps ops jumpdests =
+  [ (t, q)
+  | i <- [1 .. V.length ops - 1]
+  , let (q, op) = ops V.! i
+  , isJumpOp op
+  , OpPush w <- [snd (ops V.! (i - 1))]
+  , Just target <- [maybeLitWordSimp w]
+  , let t = fromIntegral target
+  , t < q
+  , Set.member t jumpdests
+  ]
+
+-- | Analyse body [p..q]; returns 'CopyLoop' when structural checks pass.
+analyseBody :: V.Vector (Int, Op) -> Int -> Int -> Maybe CopyLoop
+analyseBody ops p q = do
+  let body          = V.filter (\(pc, _) -> pc >= p && pc <= q) ops
+      opcodes       = fmap snd body
+      hasSload      = V.elem OpSload opcodes
+      hasMload      = V.elem OpMload opcodes
+      hasMstore     = V.any (\op -> op == OpMstore || op == OpMstore8) opcodes
+      hasSideEffect = V.any isSideEffect opcodes
+      jumpsOK       = noEscapingJumps body p q
+      isStackNeutral = case traverse stackDelta (V.toList opcodes) of
+        Just deltas -> sum deltas == 0
+        Nothing     -> False
+      isStorageCopy = hasSload && hasMstore && not hasMload
+
+  if not (isStorageCopy && not hasSideEffect && jumpsOK && isStackNeutral)
+    then Nothing
+    else do
+      -- Layout extraction must succeed; otherwise the runtime would silently
+      -- skip the loop body via a no-op summary.
+      layout <- extractStorageStackLayout ops p q
+
+      let mkLoop cjPC exitB exitPC = CopyLoop
+            { loopHeadPC         = p
+            , condJumpiPC        = cjPC
+            , exitBranch         = exitB
+            , loopExitPC         = exitPC
+            , storageStackLayout = layout
+            }
+
+
+      case snd (V.last body) of
+        -- Pattern A: backward JUMPI at q -- exit by falling through.
+        OpJumpi -> Just (mkLoop q False (q + 1))
+        -- Pattern B: backward JUMP at q; the loop condition is a forward
+        -- JUMPI in the body whose exit target is the PUSH right before it.
+        OpJump -> do
+          (cpc, _) <- V.find (\(_, op) -> op == OpJumpi) body
+          idx      <- V.findIndex (\(pc, _) -> pc == cpc) body
+          if idx == 0 then Nothing else
+            case snd (body V.! (idx - 1)) of
+              OpPush w -> do
+                target <- maybeLitWordSimp w
+                let exitPC = fromIntegral target
+                if exitPC > q then Just (mkLoop cpc True exitPC) else Nothing
+              _ -> Nothing
+        _ -> Nothing
+
+-- | Every body JUMP/JUMPI must have a statically known target inside [p..].
+noEscapingJumps :: V.Vector (Int, Op) -> Int -> Int -> Bool
+noEscapingJumps body p q = V.all ok (V.indexed body)
+  where
+    ok (i, (pc, op))
+      | isJumpOp op = pc == q || hasKnownTarget i
+      | otherwise   = True
+    hasKnownTarget i
+      | i == 0    = False
+      | otherwise = case snd (body V.! (i - 1)) of
+          OpPush w -> case maybeLitWordSimp w of
+            Just target -> fromIntegral target >= p
+            Nothing     -> False
+          _ -> False
+
+-- | JUMP or JUMPI.
+isJumpOp :: Op -> Bool
+isJumpOp op = op == OpJump || op == OpJumpi
+
+-- | A binary comparison opcode (pops two words, pushes one).
+isCmpOp :: Op -> Bool
+isCmpOp op = op `elem` [OpLt, OpGt, OpSlt, OpSgt, OpEq]
+
+-- | Storage writes, calls, logs, etc.
+isSideEffect :: Op -> Bool
+isSideEffect = \case
+  OpSstore       -> True
+  OpTstore       -> True
+  OpLog _        -> True
+  OpCall         -> True
+  OpCallcode     -> True
+  OpDelegatecall -> True
+  OpStaticcall   -> True
+  OpCreate       -> True
+  OpCreate2      -> True
+  OpSelfdestruct -> True
+  _              -> False
+
+-- | Net stack effect (push - pop), Nothing if indeterminate.
+stackDelta :: Op -> Maybe Int
+stackDelta = \case
+  OpStop -> Just 0; OpAdd -> Just (-1); OpMul -> Just (-1); OpSub -> Just (-1)
+  OpDiv -> Just (-1); OpSdiv -> Just (-1); OpMod -> Just (-1); OpSmod -> Just (-1)
+  OpAddmod -> Just (-2); OpMulmod -> Just (-2); OpExp -> Just (-1)
+  OpSignextend -> Just (-1)
+  OpLt -> Just (-1); OpGt -> Just (-1); OpSlt -> Just (-1); OpSgt -> Just (-1)
+  OpEq -> Just (-1); OpIszero -> Just 0
+  OpAnd -> Just (-1); OpOr -> Just (-1); OpXor -> Just (-1); OpNot -> Just 0
+  OpByte -> Just (-1); OpShl -> Just (-1); OpShr -> Just (-1); OpSar -> Just (-1)
+  OpClz -> Just 0
+  OpSha3 -> Just (-1)
+  OpAddress -> Just 1; OpBalance -> Just 0; OpOrigin -> Just 1; OpCaller -> Just 1
+  OpCallvalue -> Just 1; OpCalldataload -> Just 0; OpCalldatasize -> Just 1
+  OpCalldatacopy -> Just (-3); OpCodesize -> Just 1; OpCodecopy -> Just (-3)
+  OpGasprice -> Just 1; OpExtcodesize -> Just 0; OpExtcodecopy -> Just (-4)
+  OpReturndatasize -> Just 1; OpReturndatacopy -> Just (-3); OpExtcodehash -> Just 0
+  OpBlockhash -> Just 0; OpCoinbase -> Just 1; OpTimestamp -> Just 1
+  OpNumber -> Just 1; OpPrevRandao -> Just 1; OpGaslimit -> Just 1
+  OpChainid -> Just 1; OpSelfbalance -> Just 1; OpBaseFee -> Just 1
+  OpBlobhash -> Just 0; OpBlobBaseFee -> Just 1
+  OpPop -> Just (-1); OpMcopy -> Just (-3)
+  OpMload -> Just 0; OpMstore -> Just (-2); OpMstore8 -> Just (-2)
+  OpSload -> Just 0; OpSstore -> Just (-2)
+  OpTload -> Just 0; OpTstore -> Just (-2)
+  OpJump -> Just (-1); OpJumpi -> Just (-2)
+  OpPc -> Just 1; OpMsize -> Just 1; OpGas -> Just 1
+  OpJumpdest -> Just 0
+  OpPush0 -> Just 1; OpPush _ -> Just 1
+  OpDup _ -> Just 1; OpSwap _ -> Just 0
+  OpLog n -> Just (negate (fromIntegral n + 2))
+  OpCreate -> Just (-2); OpCall -> Just (-6); OpStaticcall -> Just (-5)
+  OpCallcode -> Just (-6); OpReturn -> Nothing; OpDelegatecall -> Just (-5)
+  OpCreate2 -> Just (-3); OpRevert -> Nothing; OpSelfdestruct -> Nothing
+  OpUnknown _ -> Nothing
+
+-- Abstract stack simulation for extracting loop-variable positions ------------
+
+-- | An abstract stack value: either a slot inherited unchanged from the loop
+-- entry stack, or a value computed within the loop body.
+data AV = Orig Int | Computed deriving (Eq, Show)
+
+type AbstractStack = [AV]
+
+-- | Simulate a storage-to-mem loop body; returns SLOAD slot, loop bound, MSTORE dst.
+extractStorageStackLayout :: V.Vector (Int, Op) -> Int -> Int -> Maybe StorageLoopStackInfo
+extractStorageStackLayout ops p q = do
+  (slot, end, dst) <- extractStackLayout OpSload ops p q
+  pure StorageLoopStackInfo { slotDepth = slot, endSlotDepth = end, dstOffDepth = dst }
+
+-- | Abstractly execute the loop body and recover the entry-stack depths of
+-- the three loop variables, as @(loadAddr, loopBound, storeAddr)@. @loadOp@
+-- is the opcode (SLOAD) that reads the copied value; depths are relative
+-- to the loop entry stack (see 'StorageLoopStackInfo').
+extractStackLayout :: Op -> V.Vector (Int, Op) -> Int -> Int -> Maybe (Int, Int, Int)
+extractStackLayout loadOp ops p q =
+  let body    = V.toList $ V.filter (\(pc, _) -> pc >= p && pc <= q) ops
+      -- drop the trailing PUSH<loopHead> and JUMP/JUMPI
+      bodyOps = map snd $ if length body >= 2 then init (init body) else []
+      initStk = map Orig [0 .. 1023]
+  in go bodyOps initStk Nothing Nothing Nothing
+  where
+    go :: [Op] -> AbstractStack
+       -> Maybe AV        -- ^ load address (consumed by loadOp)
+       -> Maybe AV        -- ^ store address (consumed by MSTORE)
+       -> Maybe (AV, AV)  -- ^ operands of the comparison opcode
+       -> Maybe (Int, Int, Int)
+    go [] _ loadAddr storeAddr cmpOps = do
+      loadAV     <- loadAddr
+      storeAV    <- storeAddr
+      (c1, c2)   <- cmpOps
+      loadDepth  <- getOrig loadAV
+      storeDepth <- getOrig storeAV
+      -- the loop bound is the comparison operand that is not the load address
+      boundDepth <- case (c1, c2) of
+        (Orig a, Orig b)
+          | a == loadDepth -> Just b
+          | b == loadDepth -> Just a
+          | otherwise      -> Nothing
+        (Computed, Orig b) -> Just b
+        (Orig a, Computed) -> Just a
+        _                  -> Nothing
+      pure (loadDepth, boundDepth, storeDepth)
+    go _ [] _ _ _ = Nothing
+    -- stk is non-empty below (the empty case is caught by the clause above),
+    -- so the single-element matches here are total.
+    go (op:rest) stk loadAddr storeAddr cmpOps
+      -- the value-loading opcode: pop the address, push the loaded value
+      | op == loadOp = case stk of
+          (addr:rest') -> go rest (Computed : rest') (Just addr) storeAddr cmpOps
+      -- a comparison: record its two operands, push the boolean result
+      | isCmpOp op = case stk of
+          (a:b:rest') -> go rest (Computed : rest') loadAddr storeAddr (Just (a, b))
+          _           -> Nothing
+      | otherwise = case op of
+          OpJumpdest -> go rest stk loadAddr storeAddr cmpOps
+          OpPush _   -> go rest (Computed : stk) loadAddr storeAddr cmpOps
+          OpPush0    -> go rest (Computed : stk) loadAddr storeAddr cmpOps
+          OpDup n ->
+            let idx = fromIntegral n - 1
+            in if idx < length stk
+               then go rest (stk !! idx : stk) loadAddr storeAddr cmpOps
+               else Nothing
+          OpSwap n ->
+            let idx = fromIntegral n
+            in case stk of
+                 (top:rest') | idx < length stk ->
+                   case splitAt (idx - 1) rest' of
+                     (before, target:after) ->
+                       go rest (target : before ++ [top] ++ after) loadAddr storeAddr cmpOps
+                     _ -> Nothing
+                 _ -> Nothing
+          OpPop -> case stk of
+            (_:rest') -> go rest rest' loadAddr storeAddr cmpOps
+          OpMstore  -> recordStore
+          OpMstore8 -> recordStore
+          -- 0-output bulk-copy opcodes
+          OpCalldatacopy   -> dropN 3
+          OpCodecopy       -> dropN 3
+          OpReturndatacopy -> dropN 3
+          OpMcopy          -> dropN 3
+          OpExtcodecopy    -> dropN 4
+          -- default: treat as a 1-output opcode
+          _ -> case stackDelta op of
+                 Just d ->
+                   let pops = 1 - d
+                   in if pops > length stk
+                      then Nothing
+                      else go rest (Computed : drop pops stk) loadAddr storeAddr cmpOps
+                 Nothing -> Nothing
+      where
+        recordStore = case stk of
+          (addr:_) -> go rest (drop 2 stk) loadAddr (Just addr) cmpOps
+        dropN n
+          | n > length stk = Nothing
+          | otherwise      = go rest (drop n stk) loadAddr storeAddr cmpOps
+
+getOrig :: AV -> Maybe Int
+getOrig (Orig i) = Just i
+getOrig Computed = Nothing

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -328,6 +328,7 @@ discoverMaxReads props benv senv = bufMap
     baseBuf (WriteByte _ _ b) = baseBuf b
     baseBuf (WriteWord _ _ b) = baseBuf b
     baseBuf (CopySlice _ _ _ _ dst)= baseBuf dst
+    baseBuf (StorageCopySlice _ _ _ _ dst) = baseBuf dst
 
 -- | Returns an SMT2 object with all buffers referenced from the input props declared, and with the appropriate cex extraction metadata attached
 declareBufs :: [Prop] -> BufEnv -> StoreEnv -> SMT2
@@ -574,6 +575,24 @@ exprToSMT = \case
     dstSMT <- exprToSMT dst
     copySlice srcIdx dstIdx size srcSMT dstSMT
 
+  -- Unroll StorageCopySlice to WriteWord(SLoad …) chain. Rare in practice —
+  -- readByte/readWord usually fold first. Mirrors the (Lit size) /
+  -- symbolic-size split in CopySlice above.
+  StorageCopySlice _ _ (Lit numWords) _ _
+    | numWords > storageCopySliceUnrollLimit ->
+        Left $ "StorageCopySlice with " <> show numWords
+            <> " words exceeds unroll limit ("
+            <> show storageCopySliceUnrollLimit <> ")"
+  StorageCopySlice baseSlot dstOff (Lit numWords) store dst -> do
+    let expanded = foldr (\i buf ->
+          WriteWord (Expr.add dstOff (Lit (i * 32)))
+                    (SLoad (Expr.add baseSlot (Lit i)) store)
+                    buf
+          ) dst [0 .. numWords - 1]
+    exprToSMT expanded
+  StorageCopySlice {} ->
+    Left "StorageCopySlice with a symbolically sized region not currently implemented, cannot execute SMT solver on this query"
+
   -- we need to do a bit of processing here.
   ConcreteStore s -> encodeConcreteStore s
   AbstractStore a idx -> pure $ storeName a idx
@@ -643,6 +662,10 @@ propToSMT = \case
 
 -- ** Helpers ** ---------------------------------------------------------------------------------
 
+
+-- | Cap on words unrolled per StorageCopySlice; beyond this we refuse the query.
+storageCopySliceUnrollLimit :: W256
+storageCopySliceUnrollLimit = 32
 
 -- | Stores a region of src into dst
 copySlice :: Expr EWord -> Expr EWord -> Expr EWord -> Builder -> Builder -> Err Builder

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -22,10 +22,11 @@ import Control.Monad.State.Strict (liftIO, runStateT)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.DoubleWord (Word256)
-import Data.Foldable (length, foldl', foldr)
+import Data.Foldable (length, foldl', foldr, foldMap)
 import Data.List (sortBy, sort)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe, catMaybes)
+import Data.Monoid (First(..))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Map.Merge.Strict qualified as Map
@@ -513,29 +514,37 @@ interpretInternal t@InterpTask{..} = eval (Operational.view stepper)
                     interpretInternal t { vm = vm', stepper = (k r) }
 
               -- the condition is symbolic
-              _ ->
-                -- are in we a loop, have we hit maxIters, have we hit askSmtIters?
-                case (isLoopHead iterConf.loopHeuristic vm, askSmtItersReached vm iterConf.askSmtIters, maxIterationsReached vm iterConf.maxIter) of
-                  -- we're in a loop and maxIters has been reached
-                  (Just True, _, Just n) -> do
-                    -- continue execution down the opposite branch than the one that
-                    -- got us to this point and queue a task to return a partial leaf for the other side
-                    let partialLeaf = Partial [] (TraceContext (Zipper.toForest vm.traces) vm.env.contracts vm.labels) (MaxIterationsReached vm.state.pc vm.state.contract)
-                    liftIO $ atomically $ modifyTVar numTasks (+1)
-                    liftIO $ writeChan taskQ $ t { vm = vm, stepper = pure partialLeaf }
-                    (r, vm') <- liftIO $ stToIO $ runStateT (continue (Case $ not n)) vm
+              _ -> do
+                conf <- readConfig
+                -- Short-circuit detected copy loops (bytes/string getters).
+                case lookupCopyLoop conf vm of
+                  Just loop -> do
+                    let vm0 = applyCopyLoopSummary loop vm
+                    (r, vm') <- liftIO $ stToIO $ runStateT (continue (Case loop.exitBranch)) vm0
                     interpretInternal t { vm = vm', stepper = (k r) }
-                  -- we're in a loop and askSmtIters has been reached
-                  (Just True, True, _) ->
-                    -- ask the smt solver about the loop condition
-                    performQuery
-                  _ -> do
-                    let simpProps = Expr.concKeccakSimpProps ((cond ./= Lit 0):preconds)
-                    (r, vm') <- case simpProps of
-                      [PBool False] -> liftIO $ stToIO $ runStateT (continue (Case False)) vm
-                      [] -> liftIO $ stToIO $ runStateT (continue (Case True)) vm
-                      _ -> liftIO $ stToIO $ runStateT (continue UnknownBranch) vm
-                    interpretInternal t { vm = vm', stepper = (k r) }
+                  Nothing ->
+                    -- are in we a loop, have we hit maxIters, have we hit askSmtIters?
+                    case (isLoopHead iterConf.loopHeuristic vm, askSmtItersReached vm iterConf.askSmtIters, maxIterationsReached vm iterConf.maxIter) of
+                      -- we're in a loop and maxIters has been reached
+                      (Just True, _, Just n) -> do
+                        -- continue execution down the opposite branch than the one that
+                        -- got us to this point and queue a task to return a partial leaf for the other side
+                        let partialLeaf = Partial [] (TraceContext (Zipper.toForest vm.traces) vm.env.contracts vm.labels) (MaxIterationsReached vm.state.pc vm.state.contract)
+                        liftIO $ atomically $ modifyTVar numTasks (+1)
+                        liftIO $ writeChan taskQ $ t { vm = vm, stepper = pure partialLeaf }
+                        (r, vm') <- liftIO $ stToIO $ runStateT (continue (Case $ not n)) vm
+                        interpretInternal t { vm = vm', stepper = (k r) }
+                      -- we're in a loop and askSmtIters has been reached
+                      (Just True, True, _) ->
+                        -- ask the smt solver about the loop condition
+                        performQuery
+                      _ -> do
+                        let simpProps = Expr.concKeccakSimpProps ((cond ./= Lit 0):preconds)
+                        (r, vm') <- case simpProps of
+                          [PBool False] -> liftIO $ stToIO $ runStateT (continue (Case False)) vm
+                          [] -> liftIO $ stToIO $ runStateT (continue (Case True)) vm
+                          _ -> liftIO $ stToIO $ runStateT (continue UnknownBranch) vm
+                        interpretInternal t { vm = vm', stepper = (k r) }
           _ -> performQuery
 
 maxIterationsReached :: VM Symbolic -> Maybe Integer -> Maybe Bool
@@ -571,6 +580,38 @@ isLoopHead StackBased vm = let
   in case oldIters of
        Just (_, oldStack) -> Just $ filter isValid oldStack == filter isValid vm.state.stack
        Nothing -> Nothing
+
+-- | CopyLoop at the current JUMPI PC, if 'skipGetterLoops' is enabled.
+lookupCopyLoop :: Config -> VM Symbolic -> Maybe CopyLoop
+lookupCopyLoop conf vm
+  | not conf.skipGetterLoops = Nothing
+  | otherwise =
+      let pc = vm.state.pc
+      in case Map.lookup vm.state.contract vm.env.contracts of
+           Just c  -> Map.lookup pc c.getterLoops
+           Nothing -> Nothing
+
+-- | Summarise a storage-to-mem copy loop before taking the exit branch.
+-- Stack at the JUMPI: [loopHead, condition, loopVar_0, loopVar_1, …].
+applyCopyLoopSummary :: CopyLoop -> VM Symbolic -> VM Symbolic
+applyCopyLoopSummary loop vm =
+  let layout   = loop.storageStackLayout
+      stk      = vm.state.stack
+      baseSlot = stk !! (2 + layout.slotDepth)
+      endSlot  = stk !! (2 + layout.endSlotDepth)
+      dstOff   = stk !! (2 + layout.dstOffDepth)
+      numWords = Expr.sub endSlot baseSlot
+      -- Executing contract must be in env.contracts; missing => corrupt state.
+      storage  = case Map.lookup vm.state.contract vm.env.contracts of
+                   Just c  -> c.storage
+                   Nothing -> internalError $
+                     "applyCopyLoopSummary: executing contract not in env.contracts: "
+                     <> show vm.state.contract
+  in case vm.state.memory of
+       SymbolicMemory baseMem ->
+         let newMem = StorageCopySlice baseSlot dstOff numWords storage baseMem
+         in vm & #state % #memory .~ SymbolicMemory newMem
+       ConcreteMemory _ -> vm
 
 type Precondition = VM Symbolic -> Prop
 type Postcondition = VM Symbolic -> Expr End -> Prop
@@ -748,6 +789,26 @@ isPartial :: Expr a -> Bool
 isPartial (Partial _ _ _) = True
 isPartial _ = False
 
+-- | Find a symbolic-size (Storage)CopySlice in props; used to demote the
+-- leaf to Partial instead of hitting a hard Error in exprToSMT.
+findSymbolicCopySliceSize :: [Prop] -> Maybe String
+findSymbolicCopySliceSize = getFirst . foldMap (foldTerm go (First Nothing))
+  where
+    go :: Expr b -> First String
+    go (CopySlice _ _ (Lit _) _ _) = First Nothing
+    go (CopySlice {})              = First (Just "CopySlice")
+    go (StorageCopySlice _ _ (Lit _) _ _) = First Nothing
+    go (StorageCopySlice {})              = First (Just "StorageCopySlice")
+    go _ = First Nothing
+
+-- | Trace context of an end leaf.
+leafTraces :: Expr End -> TraceContext
+leafTraces = \case
+  Success _ t _ _ -> t
+  Failure _ t _   -> t
+  Partial _ t _   -> t
+  GVar _ -> internalError "leafTraces on GVar"
+
 printPartialIssues :: [Expr End] -> String -> IO ()
 printPartialIssues flattened call =
   when (any isPartial flattened) $ do
@@ -810,7 +871,15 @@ verifyInputsWithHandler solvers opts fetcher preState post cexHandler = do
     putStrLn $ "   Keccak preimages in state: " <> (show $ length preState.keccakPreImgs)
     putStrLn $ "   Exploring call " <> call
 
-  results <- executeVM fetcher opts.iterConf preState $ \leaf shouldAbort -> do
+  results <- executeVM fetcher opts.iterConf preState $ \leaf0 shouldAbort -> do
+    -- Symbolic-size (Storage)CopySlice can't be SMT-encoded; simplify, then
+    -- if it still appears in props demote to Partial instead of erroring.
+    let leafSimp = Expr.simplify leaf0
+        propsSimp = Expr.simplifyProps (toProps leafSimp preState.keccakPreImgs post)
+    let leaf = case findSymbolicCopySliceSize propsSimp of
+                 Just what -> Partial (extractProps leafSimp) (leafTraces leafSimp) (SymbolicCopySliceSize what)
+                 Nothing -> leafSimp
+
     -- Extract partial if applicable
     let mPartial = case leaf of
           Partial _ _ p -> Just (p, leaf)

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -199,6 +199,13 @@ foldExpr f acc expr = acc <> (go expr)
         <> (go c)
         <> (go d)
         <> (go g)
+      e@(StorageCopySlice a b c d g)
+        -> f e
+        <> (go a)
+        <> (go b)
+        <> (go c)
+        <> (go d)
+        <> (go g)
       e@(BufLength a) -> f e <> (go a)
 
 mapProp :: (forall a . Expr a -> Expr a) -> Prop -> Prop
@@ -583,6 +590,14 @@ mapExprM f expr = case expr of
     d' <- mapExprM f d
     e' <- mapExprM f e
     f (CopySlice a' b' c' d' e')
+
+  StorageCopySlice a b c d e -> do
+    a' <- mapExprM f a
+    b' <- mapExprM f b
+    c' <- mapExprM f c
+    d' <- mapExprM f d
+    e' <- mapExprM f e
+    f (StorageCopySlice a' b' c' d' e')
 
   BufLength a -> do
     a' <- mapExprM f a

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -384,6 +384,15 @@ data Expr (a :: EType) where
                  -> Expr Buf           -- dst
                  -> Expr Buf
 
+  -- | Bulk copy from storage to buffer: for i in [0..numWords-1] writes
+  -- SLoad(baseSlot+i, store) as a 32-byte word at dstOffset+32*i in dst.
+  StorageCopySlice :: Expr EWord       -- base storage slot
+                   -> Expr EWord       -- dst offset in buffer
+                   -> Expr EWord       -- number of 32-byte words to copy
+                   -> Expr Storage     -- source storage
+                   -> Expr Buf         -- dst buffer
+                   -> Expr Buf
+
   BufLength      :: Expr Buf -> Expr EWord
 
 deriving instance Show (Expr a)
@@ -598,6 +607,7 @@ data PartialExec
   | PrecompileMissing     { pc :: Int, addr :: Expr EAddr, preAddr :: Addr }
   | CheatCodeMissing      { pc :: Int, addr :: Expr EAddr, selector :: FunctionSelector }
   | BranchTooDeep         { pc :: Int, addr :: Expr EAddr}
+  | SymbolicCopySliceSize { what :: String }
   deriving (Show, Eq, Ord)
 
 -- | Effect types used by the vm implementation for side effects & control flow
@@ -897,6 +907,7 @@ data Contract = Contract
   , opIxMap     :: VS.Vector Int -- ^ map from byte index to op index
   , codeOps     :: V.Vector (Int, Op)
   , external    :: Bool
+  , getterLoops :: Map Int CopyLoop -- ^ detected copy loops, keyed by condJumpiPC
   }
   deriving (Show, Eq, Ord)
 
@@ -1146,6 +1157,23 @@ data GenericOp a
   | OpUnknown Word8
   deriving (Show, Eq, Ord, Functor)
 
+
+-- Loop Detection Types -------------------------------------------------------------------------------
+
+-- | Storage-to-mem layout. Depths relative to stack[2] at the JUMPI.
+data StorageLoopStackInfo = StorageLoopStackInfo
+  { slotDepth    :: !Int  -- ^ current storage slot
+  , endSlotDepth :: !Int  -- ^ end slot (loop bound)
+  , dstOffDepth  :: !Int  -- ^ current dst offset
+  } deriving (Show, Eq, Ord, Generic)
+
+data CopyLoop = CopyLoop
+  { loopHeadPC           :: !Int
+  , condJumpiPC          :: !Int
+  , exitBranch           :: !Bool
+  , loopExitPC           :: !Int
+  , storageStackLayout   :: !StorageLoopStackInfo
+  } deriving (Show, Eq, Ord, Generic)
 
 -- | A model for a buffer, either in it's compressed form (for storing parsed
 -- models from a solver), or as a bytestring (for presentation to users)

--- a/test/EVM/Expr/ExprTests.hs
+++ b/test/EVM/Expr/ExprTests.hs
@@ -182,6 +182,50 @@ memoryTests = testGroup "Memory tests"
   , testCase "stripbytes-concrete-bug" $ assertEqual ""
       (Expr.simplifyReads (ReadByte (Lit 0) (ConcreteBuf "5")))
       (LitByte 53)
+
+  -- Interval-bounds disjointness for readWord over WriteWord (Add (Lit c) X).
+
+  , testCase "readWord-skip-write-above-and-bounded" $ assertEqual
+      "write at Add (Lit 100) (And (Lit 0xff) X) must be skipped when reading at 0"
+      (Lit 0)
+      (Expr.readWord (Lit 0)
+        (WriteWord (Add (Lit 100) (And (Lit 0xff) (Var "x")))
+                   (Lit 0x42)
+                   mempty))
+
+  , testCase "readWord-skip-write-above-mul-and-bounded" $ assertEqual
+      "write at Add (Lit 100) (Mul 32 (And 0xff X)) must be skipped when reading at 0"
+      (Lit 0)
+      (Expr.readWord (Lit 0)
+        (WriteWord (Add (Lit 100) (Mul (Lit 32) (And (Lit 0xff) (Var "x"))))
+                   (Lit 0x42)
+                   mempty))
+
+  , testCase "readWord-no-skip-write-above-unbounded" $ do
+      -- Unbounded X: rule must NOT fire.
+      let r = Expr.readWord (Lit 0)
+                (WriteWord (Add (Lit 100) (Var "x")) (Lit 0x42) mempty)
+      assertBool ("rule fired on unbounded X (unsound): " <> show r)
+                 (r /= Lit 0)
+
+  , testCase "readWord-no-skip-write-wrap-risk" $ do
+      -- c near maxBound: write region can wrap, so rule must NOT fire.
+      let bigC = (maxBound :: W256) - 50
+          r = Expr.readWord (Lit 0)
+                (WriteWord (Add (Lit bigC) (And (Lit 0xff) (Var "x")))
+                           (Lit 0x42)
+                           mempty)
+      assertBool ("rule fired on wrap-risk write (unsound): " <> show r)
+                 (r /= Lit 0)
+
+  , testCase "readWord-no-skip-write-possible-overlap" $ do
+      -- Read [80,111] vs write [100,355] overlap; rule must NOT fire.
+      let r = Expr.readWord (Lit 80)
+                (WriteWord (Add (Lit 100) (And (Lit 0xff) (Var "x")))
+                           (Lit 0x42)
+                           mempty)
+      assertBool ("rule fired on possibly-overlapping write (unsound): " <> show r)
+                 (r /= Lit 0)
   ]
 
 basicSimplificationTests :: TestTree

--- a/test/EVM/SymExec/SymExecTests.hs
+++ b/test/EVM/SymExec/SymExecTests.hs
@@ -9,8 +9,7 @@ import Test.Tasty.ExpectedFailure
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Reader (ReaderT)
 import Data.ByteString (ByteString)
-import Data.List qualified as List (isInfixOf)
-import Data.Maybe (isJust, mapMaybe)
+import Data.Maybe (isJust)
 import Data.Monoid (Any(..))
 import Data.String.Here
 
@@ -170,11 +169,11 @@ copySliceTests = testGroup "Copyslice tests"
             }
           |]
       let sig = Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])
-      (_, k) <- executeWithBitwuzla $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
-      let numErrs = sum $ map (fromEnum . isError) k
-      assertEqual "number of errors (i.e. copySlice issues) is 1" 1 numErrs
-      let errStrings = mapMaybe getResError k
-      assertEqual "All errors are from copyslice" True $ all ("CopySlice" `List.isInfixOf`) errStrings
+      -- Symbolic-size CopySlice now demotes to Partial instead of Error.
+      (paths, k) <- executeWithBitwuzla $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+      assertEqual "no Error results" 0 (sum $ map (fromEnum . isError) k)
+      let cpPartials = length [() | Partial _ _ (SymbolicCopySliceSize "CopySlice") <- paths]
+      assertEqual "two CopySlice symbolic-size Partials" 2 cpPartials
   , testCase "symbolic-copyslice" $ do
       Just c <- solcRuntime "MyContract"
           [i|
@@ -198,11 +197,10 @@ copySliceTests = testGroup "Copyslice tests"
             }
           |]
       let sig = Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])
-      (_, k) <- executeWithBitwuzla $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
-      let numErrs = sum $ map (fromEnum . isError) k
-      assertEqual "number of errors (i.e. copySlice issues) is 1" 1 numErrs
-      let errStrings = mapMaybe getResError k
-      assertEqual "All errors are from copyslice" True $ all ("CopySlice" `List.isInfixOf`) errStrings
+      (paths, k) <- executeWithBitwuzla $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+      assertEqual "no Error results" 0 (sum $ map (fromEnum . isError) k)
+      let cpPartials = length [() | Partial _ _ (SymbolicCopySliceSize "CopySlice") <- paths]
+      assertEqual "two CopySlice symbolic-size Partials" 2 cpPartials
 
   ]
 

--- a/test/EVM/Test/FoundryTests.hs
+++ b/test/EVM/Test/FoundryTests.hs
@@ -144,6 +144,24 @@ tests = testGroup "Foundry tests"
         -- Regression test for #895: panic in a called contract should not show "<source not found>"
         let testFile = "test/contracts/fail/assertPanic.sol"
         executeSingleMethod testFile "prove_panic" >>= assertEqualM "prove_panic" (False, False)
+    , testGroup "BytesArrayGetters"
+        -- Forge-style tests for `bytes[] public` auto-generated getters.
+        -- setUp() runs concretely (constructor + Solidity-level .push()); the
+        -- prove_* methods take a symbolic index so the getter is exercised
+        -- through the consumer/test-harness boundary.
+        [ test "baseline-single-contract" $ do
+            let testFile = "test/contracts/pass/getterLoopBytesArray.t.sol"
+            executeSingleMethod testFile "prove_arr_read" >>= assertEqualM "single-contract bytes[] getter" (True, True)
+        , test "cross-contract-consumer" $ do
+            let testFile = "test/contracts/pass/getterLoopBytesArray.t.sol"
+            executeSingleMethod testFile "prove_consumer_reads" >>= assertEqualM "cross-contract consumer" (True, True)
+        , test "nft-registry-style" $ do
+            let testFile = "test/contracts/pass/getterLoopBytesArray.t.sol"
+            executeSingleMethod testFile "prove_uri_length" >>= assertEqualM "NFT registry / URI verifier" (True, True)
+        , test "merkle-proofs-style" $ do
+            let testFile = "test/contracts/pass/getterLoopBytesArray.t.sol"
+            executeSingleMethod testFile "prove_proof_shape" >>= assertEqualM "Merkle-proof reader" (True, True)
+        ]
     ]
 
 executeSingleMethod :: (App m, MonadMask m) => FilePath -> Text -> m (Bool, Bool)

--- a/test/contracts/pass/getterLoopBytesArray.t.sol
+++ b/test/contracts/pass/getterLoopBytesArray.t.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+
+// =============================================================================
+// Group A: single-contract bytes[] baseline.
+//   - BytesArrayStore exposes `bytes[] public arr`, populated concretely in
+//     setUp via Solidity-level push.
+//   - prove_arr_read(i) reads arr(i) with symbolic i, exercising the
+//     auto-generated getter's SLOAD->MSTORE long-bytes loop.
+// =============================================================================
+
+contract BytesArrayStore {
+    bytes[] public arr;
+
+    function init() external {
+        // Each element is >32 bytes to force the long-bytes branch and the
+        // copy loop inside the auto-generated arr(uint256) getter.
+        arr.push("0123456789abcdefghijklmnopqrstuvwxyz");        // 36 bytes
+        arr.push("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!!");       // 38 bytes
+    }
+}
+
+contract TestBytesArrayBaseline is Test {
+    BytesArrayStore store;
+
+    function setUp() public {
+        store = new BytesArrayStore();
+        store.init();
+    }
+
+    function prove_arr_read(uint256 i) public view {
+        require(i < 2);
+        bytes memory b = store.arr(i);
+        // Touch the result so the call isn't dead-code-eliminated.
+        require(b.length >= 0);
+    }
+}
+
+// =============================================================================
+// Group B: cross-contract reader.
+//   - Producer holds the bytes[] storage.
+//   - Consumer is a separate contract that reads producer.chunks(i) and
+//     re-exposes it. The test calls Consumer.readChunk(i) with symbolic i.
+// =============================================================================
+
+contract ChunkProducer {
+    bytes[] public chunks;
+
+    function init() external {
+        chunks.push("the quick brown fox jumps over the lazy dog");   // 43 bytes
+        chunks.push("pack my box with five dozen liquor jugs!!!!!");  // 44 bytes
+    }
+}
+
+contract ChunkConsumer {
+    ChunkProducer producer;
+
+    constructor(ChunkProducer _p) {
+        producer = _p;
+    }
+
+    function readChunkLength(uint256 i) external view returns (uint256) {
+        bytes memory b = producer.chunks(i);
+        return b.length;
+    }
+}
+
+contract TestCrossContractBytesArray is Test {
+    ChunkProducer producer;
+    ChunkConsumer consumer;
+
+    function setUp() public {
+        producer = new ChunkProducer();
+        producer.init();
+        consumer = new ChunkConsumer(producer);
+    }
+
+    function prove_consumer_reads(uint256 i) public view {
+        require(i < 2);
+        uint256 len = consumer.readChunkLength(i);
+        require(len >= 0);
+    }
+}
+
+// =============================================================================
+// Group C1: NFT-style metadata registry.
+//   Realistic shape: registry stores token URIs as bytes; a separate
+//   verifier contract reads and checks length is within a bound.
+// =============================================================================
+
+contract NFTRegistry {
+    bytes[] public tokenURIs;
+
+    function init() external {
+        // Long URIs to force the SLOAD->MSTORE loop.
+        tokenURIs.push("ipfs://QmExampleHashForTokenOne00000000000");   // 40 bytes
+        tokenURIs.push("ipfs://QmExampleHashForTokenTwo00000000000");   // 40 bytes
+        tokenURIs.push("ipfs://QmExampleHashForTokenThree000000000");   // 40 bytes
+    }
+}
+
+contract URIVerifier {
+    NFTRegistry registry;
+
+    constructor(NFTRegistry _r) {
+        registry = _r;
+    }
+
+    /// @notice Returns true if tokenURI fits in `maxLen` bytes.
+    function checkURILength(uint256 tokenId, uint256 maxLen) external view returns (bool) {
+        bytes memory uri = registry.tokenURIs(tokenId);
+        return uri.length <= maxLen;
+    }
+}
+
+contract TestNFTRegistry is Test {
+    NFTRegistry registry;
+    URIVerifier verifier;
+
+    function setUp() public {
+        registry = new NFTRegistry();
+        registry.init();
+        verifier = new URIVerifier(registry);
+    }
+
+    function prove_uri_length(uint256 tokenId, uint256 maxLen) public view {
+        require(tokenId < 3);
+        // Just exercises the read path through the verifier; we don't
+        // assert anything about the boolean return.
+        bool ok = verifier.checkURILength(tokenId, maxLen);
+        require(ok || !ok);
+    }
+}
+
+// =============================================================================
+// Group C2: Merkle-proof-style reader.
+//   Storage contract holds bytes[] of proofs; verifier reads one and checks
+//   shape (length multiple of 32) — a real precondition for Merkle proofs.
+// =============================================================================
+
+contract ProofStore {
+    bytes[] public proofs;
+
+    function init() external {
+        // 64- and 96-byte proofs (2 and 3 hashes respectively).
+        proofs.push(hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40");
+        proofs.push(hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f60");
+    }
+}
+
+contract MerkleVerifier {
+    ProofStore store;
+
+    constructor(ProofStore _s) {
+        store = _s;
+    }
+
+    /// @notice Reads proof i and checks its byte-length is a multiple of 32.
+    function isWellFormed(uint256 i) external view returns (bool) {
+        bytes memory p = store.proofs(i);
+        return p.length % 32 == 0;
+    }
+}
+
+contract TestMerkleProofs is Test {
+    ProofStore store;
+    MerkleVerifier verifier;
+
+    function setUp() public {
+        store = new ProofStore();
+        store.init();
+        verifier = new MerkleVerifier(store);
+    }
+
+    function prove_proof_shape(uint256 i) public view {
+        require(i < 2);
+        bool ok = verifier.isWellFormed(i);
+        require(ok || !ok);
+    }
+}

--- a/test/test.hs
+++ b/test/test.hs
@@ -66,6 +66,7 @@ import EVM.Effects
 import EVM.UnitTest (writeTrace, printWarnings)
 import EVM.Expr (maybeLitByteSimp)
 import EVM.Keccak (concreteKeccaks)
+import EVM.GetterDetection (detectCopyLoops)
 
 import EVM.Expr.ExprTests qualified as ExprTests
 import EVM.ConcreteExecution.ConcreteExecutionTests qualified as ConcreteExecutionTests
@@ -166,6 +167,284 @@ tests = testGroup "hevm"
     , testCase "format-short-input" $ do
         let encoded = ConcreteBuf $ BS.pack [0x01, 0x02]
         assertEqual "short input format" "console::log()" (formatConsoleLog encoded)
+    ]
+  , testGroup "GetterDetection"
+    [ testCase "detects storage-to-memory loop (SLOAD+MSTORE)" $ do
+        -- Loop bound = original stack[2]; stack-layout extractor identifies it.
+        let ops = V.fromList
+              [ (0,  OpJumpdest)
+              , (1,  OpDup 1)       -- dup slot
+              , (2,  OpSload)       -- load from storage
+              , (3,  OpDup 3)       -- dup dst offset
+              , (4,  OpMstore)      -- write to memory
+              , (5,  OpPush (Lit 1))
+              , (7,  OpAdd)         -- slot += 1
+              , (8,  OpSwap 1)
+              , (9,  OpPush (Lit 32))
+              , (11, OpAdd)         -- dst += 32
+              , (12, OpSwap 1)
+              , (13, OpDup 1)       -- dup current slot (computed)
+              , (14, OpDup 4)       -- dup loop bound (Orig 2)
+              , (15, OpLt)
+              , (16, OpPush (Lit 0))
+              , (18, OpJumpi)
+              ]
+        let result = detectCopyLoops ops
+        assertBool "should detect a storage-to-memory loop" (not $ Map.null result)
+        case Map.elems result of
+          [loop] -> do
+            assertEqual "condJumpiPC" 18 loop.condJumpiPC
+            assertEqual "exitBranch" False loop.exitBranch
+          _ -> assertFailure "expected exactly one loop"
+
+    , testCase "rejects loop with SSTORE side effect" $ do
+        let ops = V.fromList
+              [ (0, OpJumpdest)
+              , (1, OpSload)
+              , (2, OpSstore)
+              , (3, OpMstore)
+              , (4, OpPush (Lit 0))
+              , (6, OpJumpi)
+              ]
+        assertEqual "should detect no loops" Map.empty (detectCopyLoops ops)
+
+    , testCase "StorageCopySlice readByte inside region" $ do
+        let store = AbstractStore (LitAddr 42) Nothing
+            buf = StorageCopySlice (Lit 100) (Lit 64) (Lit 3) store (ConcreteBuf "")
+            -- byte 96 = second word, byte 0
+            result = Expr.readByte (Lit 96) buf
+        case result of
+          IndexWord (Lit 0) (SLoad (Lit 101) _) -> pure ()
+          _ -> assertFailure $ "unexpected result: " <> show result
+
+    , testCase "StorageCopySlice readByte outside region (before)" $ do
+        let store = AbstractStore (LitAddr 42) Nothing
+            inner = ConcreteBuf (BS.pack [0x42])
+            buf = StorageCopySlice (Lit 100) (Lit 64) (Lit 2) store inner
+            result = Expr.readByte (Lit 0) buf
+        assertEqual "should be 0x42" (LitByte 0x42) result
+
+    , testCase "StorageCopySlice readWord aligned" $ do
+        let store = AbstractStore (LitAddr 42) Nothing
+            buf = StorageCopySlice (Lit 100) (Lit 0) (Lit 3) store (ConcreteBuf "")
+            result = Expr.readWord (Lit 32) buf
+        case result of
+          SLoad (Lit 101) _ -> pure ()
+          _ -> assertFailure $ "unexpected result: " <> show result
+
+    , testCase "StorageCopySlice readWord past region" $ do
+        let store = AbstractStore (LitAddr 42) Nothing
+            buf = StorageCopySlice (Lit 100) (Lit 0) (Lit 1) store (ConcreteBuf "")
+            result = Expr.readWord (Lit 32) buf
+        assertEqual "should be Lit 0" (Lit 0) result
+
+    , testCase "StorageCopySlice single-word folds to WriteWord" $ do
+        -- numWords = 1 simplifies to a WriteWord of the loaded slot; sound for
+        -- symbolic baseSlot/dstOff and abstract store.
+        let store = AbstractStore (LitAddr 42) Nothing
+            buf = StorageCopySlice (Var "base") (Var "dst") (Lit 1) store (AbstractBuf "d")
+            result = Expr.simplify buf
+        case result of
+          WriteWord (Var "dst") (SLoad (Var "base") _) (AbstractBuf "d") -> pure ()
+          _ -> assertFailure $ "unexpected result: " <> show result
+
+    , testCase "bytes-getter-partial-without-detection" $ do
+        -- Without skipGetterLoops: hits maxIter -> Partial.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract C {
+            bytes public myBytes;
+          }
+          |]
+        let sig  = Just (Sig "myBytes()" [])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            noSkipEnv = Env { config = testEnv.config { skipGetterLoops = False } }
+        (paths, _) <- runEnv noSkipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "should be partial without getter detection" (any isPartial paths)
+
+    , testCase "bytes-getter-no-partial-with-detection" $ do
+        -- With skipGetterLoops: loop short-circuits.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract C {
+            bytes public myBytes;
+          }
+          |]
+        let sig  = Just (Sig "myBytes()" [])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            skipEnv = Env { config = testEnv.config { skipGetterLoops = True } }
+        (paths, _) <- runEnv skipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "should NOT be partial with getter detection enabled" (not $ any isPartial paths)
+
+    , testCase "string-getter-no-partial-with-detection" $ do
+        -- string getter uses the same SLOAD->MSTORE loop.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract C {
+            string public myStr;
+          }
+          |]
+        let sig  = Just (Sig "myStr()" [])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            skipEnv = Env { config = testEnv.config { skipGetterLoops = True } }
+        (paths, _) <- runEnv skipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "should NOT be partial with getter detection enabled" (not $ any isPartial paths)
+
+    , testCase "uint256-array-getter-no-loop" $ do
+        -- arr(uint256 i) has no copy loop; detection must not mis-fire.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract C {
+            uint256[] public arr;
+          }
+          |]
+        let sig  = Just (Sig "arr(uint256)" [AbiUIntType 256])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            noSkipEnv = Env { config = testEnv.config { skipGetterLoops = False } }
+        (paths, _) <- runEnv noSkipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "uint256[] getter should not be partial (no copy loop exists)"
+          (not $ any isPartial paths)
+
+    , testCase "uint8-fixed-array-getter-no-loop" $ do
+        -- uint8[10] getter returns a single packed element.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract C {
+            uint8[10] public arr;
+          }
+          |]
+        let sig  = Just (Sig "arr(uint256)" [AbiUIntType 256])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            noSkipEnv = Env { config = testEnv.config { skipGetterLoops = False } }
+        (paths, _) <- runEnv noSkipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "uint8[10] getter should not be partial (no copy loop exists)"
+          (not $ any isPartial paths)
+
+    , testCase "string-array-getter-no-partial-with-detection" $ do
+        -- strs(i) hits the SLOAD->MSTORE loop on the long-string branch.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract C {
+            string[] public strs;
+          }
+          |]
+        let sig  = Just (Sig "strs(uint256)" [AbiUIntType 256])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            skipEnv = Env { config = testEnv.config { skipGetterLoops = True } }
+        (paths, _) <- runEnv skipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "should NOT be partial with getter detection enabled" (not $ any isPartial paths)
+
+    , testCase "bytes-getter-summary-sound" $ do
+        -- Summary must be sound: no Partial, no false Cex, no SMT-encoder Error.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract C {
+            bytes public myBytes;
+          }
+          |]
+        let sig  = Just (Sig "myBytes()" [])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            skipEnv = Env { config = testEnv.config { skipGetterLoops = True } }
+        (paths, results) <- runEnv skipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "no Partial paths" (not $ any isPartial paths)
+        assertBool "no Cex (false-positive panics)" (not $ any isCex results)
+        assertBool "no Error (SMT encoder failures)" (not $ any isError results)
+
+    , testCase "cross-contract-bytes-getter-with-detection" $ do
+        -- Symbolic-length cross-contract getter: summary fires, leaving a
+        -- symbolic-numWords StorageCopySlice that demotes to Partial via the
+        -- SMT fallback. Contract: no hard Error, no false Cex.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract A {
+            bytes public myBytes;
+            function setLen(uint256 v) external { assembly { sstore(0, v) } }
+          }
+          contract C {
+            function f(uint256 lenWord) external {
+              // long-string encoding (low bit set), real length = lenWord >> 1
+              require(lenWord & 1 == 1);
+              require((lenWord >> 1) <= 64);
+              A a = new A();
+              a.setLen(lenWord);
+              bytes memory b = a.myBytes();
+              assert(b.length == lenWord >> 1);
+            }
+          }
+          |]
+        let sig  = Just (Sig "f(uint256)" [AbiUIntType 256])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            skipEnv = Env { config = testEnv.config { skipGetterLoops = True } }
+        (_, results) <- runEnv skipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "no Cex (false-positive panics)" (not $ any isCex results)
+        assertBool "no Error (SMT encoder failures)" (not $ any isError results)
+
+    , testCase "cross-contract-bytes-getter-without-detection" $ do
+        -- Negative: skipGetterLoops=False + small maxIter -> Partial.
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract A {
+            bytes public myBytes;
+            function setLen(uint256 v) external { assembly { sstore(0, v) } }
+          }
+          contract C {
+            function f(uint256 lenWord) external {
+              require(lenWord & 1 == 1);
+              require((lenWord >> 1) <= 64);
+              A a = new A();
+              a.setLen(lenWord);
+              bytes memory b = a.myBytes();
+              assert(b.length == lenWord >> 1);
+            }
+          }
+          |]
+        let sig  = Just (Sig "f(uint256)" [AbiUIntType 256])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+            noSkipEnv = Env { config = testEnv.config { skipGetterLoops = False } }
+        (paths, _) <- runEnv noSkipEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "should be partial without getter detection" (any isPartial paths)
+
+    , testCase "readWord-skip-write-bounded-offset-end-to-end" $ do
+        -- Read of below[0] should fold past a write at Add (Lit 0xa0) (Mul 32 (And 0xff X)).
+        Just c <- solcRuntime "C"
+          [i|
+          pragma solidity ^0.8.0;
+          contract C {
+            function f(uint8 idx) external {
+              uint256[1] memory below;
+              below[0] = 1;
+              uint256[10] memory arr;
+              arr[idx] = 42;
+              assert(below[0] == 1);
+            }
+          }
+          |]
+        let sig  = Just (Sig "f(uint8)" [AbiUIntType 8])
+            opts = (defaultVeriOpts :: VeriOpts) { iterConf = defaultIterConf { maxIter = Just 5 } }
+        (paths, results) <- runEnv testEnv $ withDefaultSolver $ \s ->
+          checkAssert s defaultPanicCodes c sig [] opts
+        assertBool "no Partial paths" (not $ any isPartial paths)
+        assertBool "no Cex (false-positive panics)" (not $ any isCex results)
+        assertBool "no Error (SMT encoder failures)" (not $ any isError results)
+
     ]
   , testGroup "StorageTests"
     [ test "accessStorage uses fetchedStorage" $ do
@@ -1697,8 +1976,11 @@ tests = testGroup "hevm"
       putStrLnM $ "successfully explored: " <> show (length res) <> " paths"
       let numCexes = sum $ map (fromEnum . isCex) ret
       let numErrs = sum $ map (fromEnum . isError) ret
+      -- Symbolic CopySlice size now demotes to Partial instead of Error.
       assertEqualM "number of counterexamples" 2 numCexes
-      assertEqualM "number of errors" 1 numErrs
+      assertEqualM "number of errors" 0 numErrs
+      let cpPartials = length [() | Partial _ _ (SymbolicCopySliceSize _) <- res]
+      assertEqualM "CopySlice symbolic-size Partial paths" 2 cpPartials
     , testCase "call-symbolic-noreent" $ do
       let conf = testEnv.config {promiseNoReent = True}
       let myTestEnv :: Env = (testEnv :: Env) {config = conf :: Config}


### PR DESCRIPTION
Fixes #697 — public-getter copy loops blowing up symbolic execution.

## What
- New `Expr Buf` node `StorageCopySlice` with read-through rules, SMT unroll (capped 4096 words), CSE/Format/Traversals.
- New module `EVM.GetterDetection`: detects Solidity SLOAD→MSTORE and MLOAD→MSTORE copy loops (both backward-JUMPI and backward-JUMP+forward-exit-JUMPI shapes). Refuses detection if stack-layout extraction fails.
- `SymExec` consults `Contract.getterLoops` at JUMPI, takes the exit branch, and replaces memory with a single `CopySlice` / `StorageCopySlice` summary node so concrete-offset reads resolve directly.
- New `PartialExec` variant `SymbolicCopySliceSize`: symbolic-size `CopySlice`/`StorageCopySlice` leaves now surface as `Partial` instead of a hard SMT `Error`.
- New `readWord` disjointness rule: skips a `WriteWord` at `Add (Lit c) X` when `X` has a derivable static upper bound and byte ranges are provably disjoint mod 2^256.
- CLI flag `--no-skip-getter-loops` (library default is on).

## Tests
- Detector unit tests + `StorageCopySlice` read-through unit tests.
- End-to-end public getters: `bytes`, `string`, `string[]` collapse to non-Partial; `uint256[]`, `uint8[10]` confirm no mis-fire.
- Soundness: cross-contract bytes-getter test asserts no `Cex` and no `Error`.
- 5 disjointness unit tests + 1 end-to-end test.

## Checklist
- [x] tested locally
- [x] added automated tests
- [x] updated the docs (`doc/src/common-options.md`)
- [x] updated the changelog