### PR TITLE
Revert "ci: add arm64-linux release build"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
           - os: "ubuntu-latest"
             suffix: "x86_64-linux"
 
-          - os: "ubuntu-24.04-arm"
-            suffix: "arm64-linux"
-
     name: Build binary on ${{ matrix.os }}
     runs-on: ${{ matrix.os  }}
     steps:
@@ -67,7 +64,6 @@ jobs:
             ./hevm-x86_64-linux
             ./hevm-x86_64-macos
             ./hevm-arm64-macos
-            ./hevm-arm64-linux
       - name: prepare hackage artifacts
         run: |
           # cabal complains if we don't do this...


### PR DESCRIPTION
## Description

This reverts commit 5e37e203f4987425d6a5a5ca9b254d8d08a03aeb. The arm64-linux static builds are broken, and no releases of arm64-linux binaries have been made since this change was originally merged.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
