### PR TITLE
Replace imports requiring too new packages

### DIFF
--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -31,7 +31,7 @@ module EVM.SMT
 import Prelude hiding (LT, GT, Foldable(..))
 
 import Control.Monad
-import Control.Monad.Trans.Maybe (hoistMaybe)
+import Control.Monad.Trans.Maybe (MaybeT(..))
 import Data.Containers.ListUtils (nubOrd, nubInt)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
@@ -937,3 +937,7 @@ interpret1DArray = interpretNDArray interpretW256
         Just t -> interpretW256 env t
         Nothing -> internalError "unknown identifier, cannot parse array"
     interpretW256 _ t = internalError $ "cannot parse array value. Unexpected term: " <> (show t)
+
+
+hoistMaybe :: Monad m => Maybe a -> MaybeT m a
+hoistMaybe = MaybeT . pure

--- a/src/EVM/Transaction.hs
+++ b/src/EVM/Transaction.hs
@@ -12,7 +12,6 @@ import Optics.Core hiding (cons)
 
 import Data.Aeson (FromJSON (..))
 import Data.Aeson qualified as JSON
-import Data.Function (applyWhen)
 import Data.Aeson.Types qualified as JSON
 import Data.ByteString (ByteString, cons)
 import Data.ByteString qualified as BS
@@ -332,6 +331,7 @@ initTx vm =
             then Map.insert toAddr (toContract & (set #balance oldBalance))
             else touchAccount toAddr)
          $ preState
+    applyWhen p f x = if p then f x else x
   in
     vm & #env % #contracts .~ initState
        & #tx % #txReversion .~ preState


### PR DESCRIPTION
This PR removes two imports that require newer versions of packages than we promise in our cabal file.
Since we build our static build with older version of GHC, we cannot yet bump those requirements.
