### PR TITLE
Decode cheatcode string args leniently instead of crashing on invalid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- Cheatcode string arguments are now decoded leniently instead of crashing on
+  invalid UTF-8: ABI `string` values are raw bytes, so e.g. `vm.setEnv`,
+  `vm.envString` and `vm.label` no longer abort the whole run when handed a
+  byte sequence that is not valid UTF-8 ([#1076](https://github.com/argotorg/hevm/issues/1076))
+
 ## [0.58.0] - 2026-06-26
 
 ## Added

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -52,7 +52,8 @@ import Data.Set (insert, member, fromList)
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import Data.Text (unpack, pack)
-import Data.Text.Encoding (decodeUtf8)
+import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding.Error (lenientDecode)
 import Data.Tree
 import Data.Tree.Zipper qualified as Zipper
 import Data.Typeable
@@ -2076,7 +2077,7 @@ cheatActions = Map.fromList
       \sig input -> case decodeBuf [AbiAddressType, AbiStringType] input of
         (CAbi valsArr,"") -> case valsArr of
           [AbiAddress addr, AbiString label] -> do
-            #labels %= Map.insert addr (decodeUtf8 label)
+            #labels %= Map.insert addr (decodeUtf8With lenientDecode label)
             doStop
           _ -> vmError (BadCheatCode "label(address,string) address decoding failed" sig)
         _ -> vmError (BadCheatCode "label(address,string) parameter decoding failed" sig)
@@ -2268,7 +2269,9 @@ cheatActions = Map.fromList
       assign #result Nothing
       cont
     doStop = finishFrame (FrameReturned mempty)
-    toString = unpack . decodeUtf8
+    -- ABI strings are raw bytes with no enforced encoding, so decode
+    -- leniently: invalid UTF-8 must not crash cheatcode handling (#1076)
+    toString = unpack . decodeUtf8With lenientDecode
     strip0x s = if "0x" `isPrefixOf` s then drop 2 s else s
     stringToBool :: String -> Either ByteString Bool
     stringToBool s = case s of

--- a/test/contracts/pass/cheatCodes.sol
+++ b/test/contracts/pass/cheatCodes.sol
@@ -311,6 +311,17 @@ contract CheatCodes is Test {
         assertEq(result[3], "0xffff");
     }
 
+    function prove_invalidUTF8() public {
+        // ABI strings are raw bytes and need not be valid UTF-8: byte 0xbf
+        // must not crash cheatcode string handling (issue #1076)
+        string memory invalid = string(abi.encodePacked(hex"bf"));
+
+        hevm.setEnv(invalid, "hello, world!");
+        assertEq(hevm.envString(invalid), "hello, world!");
+
+        hevm.label(address(this), invalid);
+    }
+
     function prove_envBytes() public {
         bytes memory varname = "ENV_BYTES_TEST";
 


### PR DESCRIPTION
Fixes #1076.

## Problem

Solidity ABI `string` values are raw byte sequences at runtime — the EVM does not enforce UTF-8 validity. The cheatcode handlers decoded string arguments with the partial `Data.Text.Encoding.decodeUtf8`, so passing a string containing an invalid byte (e.g. `0xbf`) through `vm.setEnv` / `vm.envString` / `vm.label` crashed the entire run:

```
Cannot decode byte '\xbf': Data.Text.Encoding: Invalid UTF-8 stream
```

This is reachable from fuzzers driving hevm (the report came from an Echidna campaign generating arbitrary string calldata).

## Fix

Two call sites, three lines of logic: replace `decodeUtf8` with `decodeUtf8With lenientDecode` in

- `toString` — the shared helper all `env*` cheatcodes, `setEnv` and `ffi` funnel through, and
- the `label(address,string)` handler.

Invalid bytes decode to U+FFFD instead of throwing. `setEnv`/`envString` stay consistent because both sides decode the key the same way, so lookups still round-trip.

These are the only partial-decode sites reachable from cheatcode string arguments: `createFork` already uses `Char8.unpack`, and assert messages / trace rendering go through the total `decodeUtf8'`-with-hex-fallback path in `EVM.Format`.

## Performance / scope

`decodeUtf8With lenientDecode` is the same single validating pass as `decodeUtf8` — no extra cost for valid strings, no behaviour change for valid UTF-8.

## Testing

- New `prove_invalidUTF8` in `test/contracts/pass/cheatCodes.sol` (runs in the `Cheat-Codes-Pass` group), mirroring the issue reproducer: `setEnv` with a `0xbf` key, `envString` round-trip, `label` with invalid bytes.
- Verified on the reproducer project: pre-fix binary crashes with the exact error above; post-fix it reports `[PASS]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
