### PR TITLE
ci: pin z3 on windows to 4.15.2 (official release binary)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,6 @@ jobs:
             autotools:p
             gmp:p
             openssl:p
-            z3:p
             go:p
       - uses: haskell-actions/setup@v2.7.7
         id: setup
@@ -247,6 +246,11 @@ jobs:
           curl --retry 5 -fsSL https://github.com/bitwuzla/bitwuzla/releases/download/0.8.2/Bitwuzla-Win64-x86_64-static.zip -o bitwuzla.zip
           unzip bitwuzla.zip && rm bitwuzla.zip
           echo BITWUZLA_PATH="$PWD/Bitwuzla-Win64-x86_64-static/bin" >> "$GITHUB_ENV"
+          # z3, pinned: msys2's rolling z3 package broke 3 tests when it moved
+          # from 4.15.2 to 4.16.0 (upstream 4.16.0 is fine on other platforms)
+          curl --retry 5 -fsSL https://github.com/Z3Prover/z3/releases/download/z3-4.15.2/z3-4.15.2-x64-win.zip -o z3.zip
+          unzip z3.zip && rm z3.zip
+          echo Z3_PATH="$PWD/z3-4.15.2-x64-win/bin" >> "$GITHUB_ENV"
           # evm
           go install github.com/ethereum/go-ethereum/cmd/evm@v1.16.1
           echo EVM_PATH="$(cygpath -u "$(go env GOPATH)/bin")" >> "$GITHUB_ENV"
@@ -266,14 +270,14 @@ jobs:
 
       - name: run tests
         run: |
-          export PATH="$EVM_PATH:$CVC5_PATH:$BITWUZLA_PATH:$DAPP_SOLC_PATH:$FOUNDRY_PATH:$HASKELL_PATHS:$PATH"
+          export PATH="$EVM_PATH:$CVC5_PATH:$BITWUZLA_PATH:$Z3_PATH:$DAPP_SOLC_PATH:$FOUNDRY_PATH:$HASKELL_PATHS:$PATH"
           cabal run test
 
       - name: run rpc tests
         env:
           RPC_MAINNET_KEY: ${{ secrets.RPC_MAINNET_KEY }}
         run: |
-          export PATH="$BITWUZLA_PATH:$FOUNDRY_PATH:$HASKELL_PATHS:$PATH"
+          export PATH="$BITWUZLA_PATH:$Z3_PATH:$FOUNDRY_PATH:$HASKELL_PATHS:$PATH"
           cabal run rpc-tests
 
       - name: run ethereum tests


### PR DESCRIPTION
## Problem

The `build (windows-latest)` job currently fails on every PR (e.g. #1080) with 3 test failures:

- `negative-numbers-zero-comp` — expected 1 counterexample, got 0
- `negative-numbers-zero-comp-simpleassert` — expected 1 counterexample, got 0
- `eq-issue-with-length-cex-bug679` — cex found but doesn't match the expected model

This is unrelated to any recent hevm change: the windows job installs z3 via msys2's **rolling** package repo (`z3:p` in the pacboy list), so each run silently picks up whatever msys2 currently ships.

- Last green run on `main` (Jul 6): msys2 z3 **4.15.2-5**
- Failing runs now: msys2 z3 **4.16.0-1**

I could not reproduce any of the three failures with the **official** z3 4.16.0 release binary (macOS): `hevm symbolic` on `assert(x >= 0)` finds the counterexample, and the bug679 equivalence check produces the exact expected `0xff…fe0c` calldata. So the breakage looks specific to the msys2 4.16.0 package (or z3-4.16-on-windows), not to upstream z3 4.16 semantics generally.

## Fix

Install z3 on windows from the official Z3Prover release archive, pinned to **4.15.2** (the last version windows CI was green on) — exactly the pattern this job already uses for bitwuzla (0.8.2) and cvc5 (1.3.0). `$Z3_PATH` is added to the test and rpc-test PATH exports.

Solver upgrades on windows now happen via an explicit, bisectable diff instead of silently on the runner image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
