### PR TITLE
[RFC] Add construction-time hash-consing for Expr (hashConsExplore)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- New experimental `hashConsExplore` config option (off by default): construction-time
+  hash-consing of the symbolic VM state (new `EVM.HashCons` module), so structurally
+  shared terms stay DAGs instead of materializing as exponential trees during
+  exploration. The `Expr` `Eq`/`Ord` instances gained a pointer-equality fast path
+  (identical semantics to the derived ones), and the repeatedly-applied simplifier
+  passes memoize per-node fixpoints when hash-consing is on. Addresses storage-heavy
+  targets where a 914-node DAG materialized as a 601,664-node tree (22 GB peak).
+
 ## Fixed
 - Cheatcode string arguments are now decoded leniently instead of crashing on
   invalid UTF-8: ABI `string` values are raw bytes, so e.g. `vm.setEnv`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (identical semantics to the derived ones), and the repeatedly-applied simplifier
   passes memoize per-node fixpoints when hash-consing is on. Addresses storage-heavy
   targets where a 914-node DAG materialized as a 601,664-node tree (22 GB peak).
+  Enabled from the CLI with `--hash-cons`; the test suites run with it enabled so the
+  sharing machinery is exercised everywhere.
 
 ## Fixed
 - Cheatcode string arguments are now decoded leniently instead of crashing on

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -103,6 +103,7 @@ data CommonOptions = CommonOptions
   , earlyAbort    ::Bool
   , mergeMaxBudget :: Int
   , maxDynSize    ::Int
+  , hashCons      ::Bool
   }
 
 commonOptions :: Parser CommonOptions
@@ -135,6 +136,7 @@ commonOptions = CommonOptions
   <*> (switch $  long "early-abort" <> help "Stop exploration immediately upon finding the first counterexample")
   <*> (option auto $ long "merge-max-budget" <> showDefault <> value 100 <> help "Max instructions for speculative merge exploration during path merging")
   <*> (option auto $ long "max-dyn-size" <> showDefault <> value 64 <> help "Max byte length for concretized dynamic types (bytes, string) in symbolic arguments")
+  <*> (switch $ long "hash-cons" <> help "Experimental: hash-cons (share equal subterms of) the symbolic VM state during exploration, reducing memory use on targets that build deeply-shared terms")
 
 data CommonExecOptions = CommonExecOptions
   { address       ::Maybe Addr
@@ -380,6 +382,7 @@ main = do
         , earlyAbort = cOpts.earlyAbort
         , mergeMaxBudget = cOpts.mergeMaxBudget
         , maxDynSize = cOpts.maxDynSize
+        , hashConsExplore = cOpts.hashCons
         } }
 
 

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -113,6 +113,7 @@ library
     EVM.SymExec,
     EVM.Traversals,
     EVM.CSE,
+    EVM.HashCons,
     EVM.Keccak,
     EVM.Merge,
     EVM.Transaction,

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -14,6 +14,7 @@ import EVM.ABI
 import EVM.Expr (readStorage, concStoreContains, writeStorage, readByte, readWord, writeWord,
   writeByte, bufLength, indexWord, readBytes, copySlice, wordToAddr, maybeLitByteSimp, maybeLitWordSimp, maybeLitAddrSimp)
 import EVM.Expr qualified as Expr
+import EVM.HashCons qualified as HashCons
 import EVM.FeeSchedule (FeeSchedule (..))
 import EVM.FeeSchedule qualified as Fees (feeSchedule)
 import EVM.Merge qualified as Merge
@@ -497,7 +498,7 @@ exec1 conf = do
                           modifying #keccakPreImgs (insert (bs, kc))
                           pure $ Lit kc
                         )
-                    buf -> pure $ Keccak buf
+                    buf -> pure $ HashCons.internExpr (Keccak buf)
                   next
                   assign' (#state % #stack) (hash : xs)
             _ -> underrun
@@ -795,7 +796,8 @@ exec1 conf = do
 
                 symbolicRead :: EVM t () = if this.external
                   then accessStorage self x finalizeLoad
-                  else finalizeLoad $ Expr.readStorage' (Expr.concKeccakOnePass x) this.storage
+                  else let slot = HashCons.internExpr (Expr.concKeccakOnePass x)
+                       in finalizeLoad $ HashCons.internExpr (Expr.readStorage' slot this.storage)
 
                 concreteRead :: EVM t () = do
                   acc <- accessStorageForGas self (forceLit x)
@@ -3277,7 +3279,7 @@ stackOp1 cost f =
     x:xs ->
       burn cost $ do
         next
-        let !y = f x
+        let !y = HashCons.internExpr (f x)
         assign' (#state % #stack) $ y : xs
     _ ->
       underrun
@@ -3292,7 +3294,7 @@ stackOp2 cost f =
     x:y:xs ->
       burn cost $ do
         next
-        assign' (#state % #stack) $ f x y : xs
+        assign' (#state % #stack) $ HashCons.internExpr (f x y) : xs
     _ ->
       underrun
 
@@ -3306,7 +3308,7 @@ stackOp3 cost f =
     x:y:z:xs ->
       burn cost $ do
       next
-      assign' (#state % #stack) $ f x y z : xs
+      assign' (#state % #stack) $ HashCons.internExpr (f x y z) : xs
     _ ->
       underrun
 

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -49,6 +49,9 @@ data Config = Config
   , earlyAbort       :: Bool
   , mergeMaxBudget   :: Int        -- ^ Max instructions for speculative merge exploration
   , maxDynSize       :: Int        -- ^ Max byte length for concretized dynamic types (bytes, string)
+  , hashConsExplore  :: Bool       -- ^ Hash-cons (share equal subterms of) the live symbolic VM
+                                   -- state as it is built, so a shared DAG never materializes as
+                                   -- an exponential tree during exploration. See EVM.HashCons.
   }
   deriving (Show, Eq)
 
@@ -71,6 +74,7 @@ defaultConfig = Config
   , earlyAbort = False
   , mergeMaxBudget = 100
   , maxDynSize = 64
+  , hashConsExplore = False
   }
 
 -- Write to the console

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -159,6 +159,7 @@ import Data.Word (Word8, Word32)
 import Witch (unsafeInto, into, tryInto)
 import Data.Containers.ListUtils (nubOrd)
 
+import EVM.HashCons qualified as HC
 import EVM.Traversals
 import EVM.Types
 
@@ -837,6 +838,12 @@ readStorage w st = go (simplifyNoLitToKeccak w) (simplifyNoLitToKeccak st)
     go slot s@(SStore prevSlot val prev) = case (prevSlot, slot) of
       -- if address and slot match then we return the val in this write
       _ | prevSlot == slot -> Just val
+      -- Fast path for concrete keys: two distinct literal slots (equality already handled above)
+      -- can never alias, so skip straight down the write chain without invoking surelyEqual/
+      -- surelyNotEqual (which each run the simplifier). This makes reading through a long chain of
+      -- concrete SStores — e.g. a symbolic contract whose setup did many concrete writes over an
+      -- AbstractStore base — O(chain) cheap compares instead of O(chain) simplifier calls.
+      (Lit _, Lit _) -> go slot prev
       (a, b) | surelyEqual a b -> Just val
       (a, b) | surelyNotEqual a b -> go slot prev
 
@@ -970,7 +977,7 @@ litToArrayPreimage val =
       Nothing
 
 litToKeccak :: Expr a -> Expr a
-litToKeccak e = mapExpr go e
+litToKeccak e = mapExprShared 0 go e
   where
     go :: Expr a -> Expr a
     go orig@(Lit key) = case litToArrayPreimage key of
@@ -1185,12 +1192,12 @@ decomposeStorage = go
 -- | Simple recursive match based AST simplification
 -- Note: may not terminate!
 simplify :: Expr a -> Expr a
-simplify e = untilFixpoint (simplifyNoLitToKeccak . litToKeccak) e
+simplify e = untilFixpoint (simplifyNoLitToKeccak . litToKeccak) (HC.internExpr e)
 
 simplifyNoLitToKeccak :: Expr a -> Expr a
 simplifyNoLitToKeccak l@(Lit _) = l
 simplifyNoLitToKeccak s@(ConcreteStore _) = s
-simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
+simplifyNoLitToKeccak e = untilFixpoint (mapExprShared 1 go) (HC.internExpr e)
   where
     go :: Expr a -> Expr a
 
@@ -2063,7 +2070,7 @@ constPropagate ps =
 
 -- Concretize & simplify Keccak expressions until fixed-point.
 concKeccakSimpExpr :: Expr a -> Expr a
-concKeccakSimpExpr orig = untilFixpoint (simplifyNoLitToKeccak . (mapExpr concKeccakOnePass)) (simplify orig)
+concKeccakSimpExpr orig = untilFixpoint (simplifyNoLitToKeccak . (mapExprShared 2 concKeccakOnePass)) (simplify orig)
 
 -- Concretize Keccak in Props, but don't simplify
 -- Needed because if it also simplified, we may not find some simplification errors, as

--- a/src/EVM/HashCons.hs
+++ b/src/EVM/HashCons.hs
@@ -1,0 +1,553 @@
+{- |
+    Module: EVM.HashCons
+    Description: Construction-time hash-consing (structural sharing) for the Expr AST.
+
+    The symbolic interpreter rebuilds structurally-identical subterms as separate heap objects
+    (e.g. a mapping-slot keccak recomputed on every storage access), so a computation that reuses
+    an intermediate at k nesting levels materializes a 2^k tree with no sharing. On storage-heavy
+    targets this exhausts memory (observed: a 914-node DAG materialized as a 601,664-node tree,
+    22 GB peak), and it makes every structural traversal or comparison pay the logical - not the
+    shared - size.
+
+    'internExpr' returns a canonical representative for a node: the first structurally-equal node
+    ever seen is reused for all later duplicates, so the heap holds the DAG, not the tree. It is
+    exact (never merges structurally-different terms) and O(1) amortized per constructed node:
+
+      * a StableName table shortcuts nodes that are ALREADY canonical, so canonical subtrees
+        (e.g. operands taken off the stack) are not re-traversed, and
+      * the structural tables are keyed by (constructor tag, scalar payload, child ids) - all
+        shallow - so a lookup never compares whole subterms.
+
+    Canonicalization also makes physical identity a cheap witness for structural equality, which
+    the ptrEq fast paths in Expr's Eq/Ord instances and 'untilFixpoint' exploit: comparisons on
+    shared terms drop from O(logical size) to O(size of the differing part).
+
+    internExpr e is always structurally equal to e, so it is semantically the identity; it only
+    shares memory. Gated by 'setHashConsEnabled' (off by default): when disabled every call is a
+    single IORef read returning the argument unchanged, so ordinary (non-symbolic) use is
+    unaffected.
+
+    The tables are module-global state in the style of GHC's FastString table: this module is the
+    only code that can touch them, a canonical node never changes meaning (the tables are only
+    ever consulted to return an already-constructed, structurally-equal node), and
+    'resetHashCons' is called at the start of each symbolic exploration so entries never leak
+    between runs.
+-}
+module EVM.HashCons
+  ( internExpr
+  , setHashConsEnabled
+  , hashConsEnabled
+  , resetHashCons
+  , memoFixTraverse
+  ) where
+
+import Prelude hiding (LT, GT)
+import Data.IORef
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
+import Data.IntMap.Strict qualified as IM
+import Control.Monad (forM)
+import Data.Foldable (toList)
+import Data.Word (Word8)
+import Data.Text (Text)
+import Data.ByteString (ByteString)
+import System.IO.Unsafe (unsafePerformIO)
+import System.Mem.StableName
+
+import EVM.Types
+
+-- | Scalar data carried by leaf/annotated constructors, folded into the structural key so that
+-- e.g. two different literals are never merged.
+data Payload
+  = P0
+  | PW  !W256
+  | PT  !Text
+  | PB8 !Word8
+  | PBS !ByteString
+  | PAddr !Addr
+  | PMW !(Maybe W256)
+  | PStore ![(W256, W256)]
+  | PGas !Text !Int
+  | PInt !Int
+  deriving (Eq, Ord)
+
+-- | Structural key: constructor tag, scalar payload, child ids. All shallow.
+type Key = (Int, Payload, [Int])
+
+-- | A type-erased StableName. 'eqStableName' compares heterogeneously, so no coercion is ever
+-- needed to look a name up again.
+data SomeSN = forall x. SomeSN !(StableName x)
+
+-- | One canonical-node table per expression type, so nodes are recovered at their own type and
+-- no unsafe coercion is involved anywhere.
+data HCState = HCState
+  { hcWords  :: !(Map Key (Expr EWord))
+  , hcBytes  :: !(Map Key (Expr Byte))
+  , hcBufs   :: !(Map Key (Expr Buf))
+  , hcStores :: !(Map Key (Expr Storage))
+  , hcAddrs  :: !(Map Key (Expr EAddr))
+  , hcSns    :: !(IM.IntMap [(SomeSN, Int)])  -- ^ hashStableName -> [(name, id)]: node -> id
+  , hcKeyIds :: !(Map Key Int)                -- ^ structural key -> id
+  , hcNext   :: !Int
+  }
+
+emptyHC :: HCState
+emptyHC = HCState M.empty M.empty M.empty M.empty M.empty IM.empty M.empty 0
+
+{-# NOINLINE hcEnabled #-}
+hcEnabled :: IORef Bool
+hcEnabled = unsafePerformIO (newIORef False)
+
+{-# NOINLINE hcState #-}
+hcState :: IORef HCState
+hcState = unsafePerformIO (newIORef emptyHC)
+
+setHashConsEnabled :: Bool -> IO ()
+setHashConsEnabled = writeIORef hcEnabled
+
+resetHashCons :: IO ()
+resetHashCons = do
+  writeIORef hcState emptyHC
+  writeIORef passMemos IM.empty
+
+-- | Per-pass memo of simplification results, keyed by canonical node id, with one table per
+-- expression type. Values are recovered at their own type by dispatching on the node's
+-- constructor (which fixes the type via GADT refinement), so no coercion is involved. Cleared
+-- together with the intern tables.
+data MemoTables = MemoTables
+  { mtW  :: !(IM.IntMap (Expr EWord))
+  , mtBy :: !(IM.IntMap (Expr Byte))
+  , mtBu :: !(IM.IntMap (Expr Buf))
+  , mtS  :: !(IM.IntMap (Expr Storage))
+  , mtA  :: !(IM.IntMap (Expr EAddr))
+  }
+
+emptyMT :: MemoTables
+emptyMT = MemoTables IM.empty IM.empty IM.empty IM.empty IM.empty
+
+{-# NOINLINE passMemos #-}
+passMemos :: IORef (IM.IntMap MemoTables)
+passMemos = unsafePerformIO (newIORef IM.empty)
+
+-- | Which typed memo table a node's results live in, decided by its constructor. GADT matching
+-- refines the type, so reads come back at the node's own type. Nodes of types we do not memo
+-- (End, Log, EContract) return Nothing and are simply recomputed.
+data TableAt a = TableAt
+  { readT  :: MemoTables -> IM.IntMap (Expr a)
+  , writeT :: MemoTables -> IM.IntMap (Expr a) -> MemoTables
+  }
+
+tableFor :: Expr a -> Maybe (TableAt a)
+tableFor e = case e of
+  Lit{} -> w; Var{} -> w; Origin -> w; Coinbase -> w; Timestamp -> w; BlockNumber -> w
+  PrevRandao -> w; GasLimit -> w; ChainId -> w; BaseFee -> w; TxValue -> w; Gas{} -> w
+  IsZero{} -> w; Not{} -> w; CLZ{} -> w; BlockHash{} -> w; Keccak{} -> w; BufLength{} -> w
+  WAddr{} -> w; Balance{} -> w; CodeSize{} -> w; CodeHash{} -> w
+  Add{} -> w; Sub{} -> w; Mul{} -> w; Div{} -> w; SDiv{} -> w; Mod{} -> w; SMod{} -> w
+  Exp{} -> w; SEx{} -> w; Min{} -> w; Max{} -> w
+  LT{} -> w; GT{} -> w; LEq{} -> w; GEq{} -> w; SLT{} -> w; SGT{} -> w; Eq{} -> w
+  And{} -> w; Or{} -> w; Xor{} -> w; SHL{} -> w; SHR{} -> w; SAR{} -> w
+  EqByte{} -> w; ReadWord{} -> w; AddMod{} -> w; MulMod{} -> w; ITE{} -> w; SLoad{} -> w
+  JoinBytes{} -> w
+  LitByte{} -> by; IndexWord{} -> by; ReadByte{} -> by
+  ConcreteBuf{} -> bu; AbstractBuf{} -> bu; WriteWord{} -> bu; WriteByte{} -> bu; CopySlice{} -> bu
+  ConcreteStore{} -> st; AbstractStore{} -> st; SStore{} -> st
+  SymAddr{} -> ad; LitAddr{} -> ad
+  _ -> Nothing
+  where
+    w  = Just (TableAt (.mtW)  (\m t -> m { mtW = t }))
+    by = Just (TableAt (.mtBy) (\m t -> m { mtBy = t }))
+    bu = Just (TableAt (.mtBu) (\m t -> m { mtBu = t }))
+    st = Just (TableAt (.mtS)  (\m t -> m { mtS = t }))
+    ad = Just (TableAt (.mtA)  (\m t -> m { mtA = t }))
+
+-- | Read the enable flag with a data dependency on the argument so the check cannot be floated
+-- out and shared across calls (the flag changes between explorations).
+hashConsEnabled :: Expr b -> Bool
+hashConsEnabled x = unsafePerformIO (x `seq` readIORef hcEnabled)
+{-# NOINLINE hashConsEnabled #-}
+
+-- | Intern a node (and, as needed, its not-yet-canonical descendants) to a canonical
+-- representative. Semantically the identity.
+internExpr :: Expr a -> Expr a
+internExpr e = unsafePerformIO $ do
+  en <- readIORef hcEnabled
+  if en then fst <$> go e else pure e
+{-# NOINLINE internExpr #-}
+
+-- Look up a node's id by physical identity. A hit means the node is already canonical.
+lookupSN :: Expr a -> IO (Maybe Int)
+lookupSN e = do
+  sn <- makeStableName $! e
+  st <- readIORef hcState
+  pure $ case IM.lookup (hashStableName sn) st.hcSns of
+    Nothing -> Nothing
+    Just bucket -> lookupBucket sn bucket
+  where
+    lookupBucket :: StableName x -> [(SomeSN, Int)] -> Maybe Int
+    lookupBucket _ [] = Nothing
+    lookupBucket sn ((SomeSN sn', i):rest)
+      | eqStableName sn sn' = Just i
+      | otherwise = lookupBucket sn rest
+
+-- Record a canonical node's StableName -> id (atomic; interpreters may run concurrently).
+recordSN :: Expr a -> Int -> IO ()
+recordSN e i = do
+  sn <- makeStableName $! e
+  atomicModifyIORef' hcState $ \st ->
+    (st { hcSns = IM.insertWith (++) (hashStableName sn) [(SomeSN sn, i)] st.hcSns }, ())
+
+-- Canonicalize a rebuilt node (children already canonical) by its structural key, in the table
+-- selected by the caller (which fixes the type). The id counter is bumped atomically so
+-- concurrent interpreters can never hand out the same id for different structures.
+recanonIn :: (HCState -> Map Key (Expr a))
+          -> (HCState -> Map Key (Expr a) -> HCState)
+          -> Key -> Expr a -> IO (Expr a, Int)
+recanonIn getT setT key e' = do
+  r <- atomicModifyIORef' hcState $ \st ->
+    case M.lookup key (getT st) of
+      Just c -> (st, Left (c, M.findWithDefault (-1) key st.hcKeyIds))
+      Nothing ->
+        let i = st.hcNext
+            st' = (setT st (M.insert key e' (getT st)))
+                    { hcKeyIds = M.insert key i st.hcKeyIds, hcNext = i + 1 }
+        in (st', Right i)
+  case r of
+    Left (c, i) -> pure (c, i)
+    Right i     -> do recordSN e' i; pure (e', i)
+
+recanonW :: Key -> Expr EWord -> IO (Expr EWord, Int)
+recanonW = recanonIn (.hcWords) (\st t -> st { hcWords = t })
+
+recanonBy :: Key -> Expr Byte -> IO (Expr Byte, Int)
+recanonBy = recanonIn (.hcBytes) (\st t -> st { hcBytes = t })
+
+recanonBu :: Key -> Expr Buf -> IO (Expr Buf, Int)
+recanonBu = recanonIn (.hcBufs) (\st t -> st { hcBufs = t })
+
+recanonS :: Key -> Expr Storage -> IO (Expr Storage, Int)
+recanonS = recanonIn (.hcStores) (\st t -> st { hcStores = t })
+
+recanonA :: Key -> Expr EAddr -> IO (Expr EAddr, Int)
+recanonA = recanonIn (.hcAddrs) (\st t -> st { hcAddrs = t })
+
+-- Assign a fresh id without structural deduping (constructors we do not key, e.g. End nodes).
+-- Recording the StableName still makes the object canonical-by-identity on later encounters.
+freshOpaque :: Expr a -> IO (Expr a, Int)
+freshOpaque e = do
+  i <- atomicModifyIORef' hcState $ \st -> (st { hcNext = st.hcNext + 1 }, st.hcNext)
+  recordSN e i
+  pure (e, i)
+
+-- Top-down: shortcut already-canonical nodes, else canonicalize bottom-up.
+go :: Expr a -> IO (Expr a, Int)
+go e = do
+  m <- lookupSN e
+  case m of
+    Just i  -> pure (e, i)
+    Nothing -> goBuild e
+
+w1 :: Int -> (Expr EWord -> Expr EWord) -> Expr EWord -> IO (Expr EWord, Int)
+w1 t con a = do (a', ia) <- go a; recanonW (t, P0, [ia]) (con a')
+
+w2 :: Int -> (Expr EWord -> Expr EWord -> Expr EWord) -> Expr EWord -> Expr EWord -> IO (Expr EWord, Int)
+w2 t con a b = do (a', ia) <- go a; (b', ib) <- go b; recanonW (t, P0, [ia, ib]) (con a' b')
+
+w3 :: Int -> (Expr EWord -> Expr EWord -> Expr EWord -> Expr EWord)
+   -> Expr EWord -> Expr EWord -> Expr EWord -> IO (Expr EWord, Int)
+w3 t con a b c = do
+  (a', ia) <- go a; (b', ib) <- go b; (c', ic) <- go c
+  recanonW (t, P0, [ia, ib, ic]) (con a' b' c')
+
+goBuild :: Expr a -> IO (Expr a, Int)
+goBuild = \case
+  -- EWord leaves / block & tx context
+  Lit w            -> recanonW (1, PW w, []) (Lit w)
+  Var t            -> recanonW (2, PT t, []) (Var t)
+  Origin           -> recanonW (3, P0, []) Origin
+  Coinbase         -> recanonW (4, P0, []) Coinbase
+  Timestamp        -> recanonW (5, P0, []) Timestamp
+  BlockNumber      -> recanonW (6, P0, []) BlockNumber
+  PrevRandao       -> recanonW (7, P0, []) PrevRandao
+  GasLimit         -> recanonW (8, P0, []) GasLimit
+  ChainId          -> recanonW (9, P0, []) ChainId
+  BaseFee          -> recanonW (10, P0, []) BaseFee
+  TxValue          -> recanonW (11, P0, []) TxValue
+  Gas p i          -> recanonW (12, PGas p i, []) (Gas p i)
+  -- EWord unary
+  IsZero a         -> w1 20 IsZero a
+  Not a            -> w1 21 Not a
+  CLZ a            -> w1 22 CLZ a
+  BlockHash a      -> w1 23 BlockHash a
+  Keccak a         -> do (a', ia) <- go a; recanonW (24, P0, [ia]) (Keccak a')
+  BufLength a      -> do (a', ia) <- go a; recanonW (25, P0, [ia]) (BufLength a')
+  WAddr a          -> do (a', ia) <- go a; recanonW (26, P0, [ia]) (WAddr a')
+  Balance a        -> do (a', ia) <- go a; recanonW (27, P0, [ia]) (Balance a')
+  CodeSize a       -> do (a', ia) <- go a; recanonW (28, P0, [ia]) (CodeSize a')
+  CodeHash a       -> do (a', ia) <- go a; recanonW (29, P0, [ia]) (CodeHash a')
+  -- EWord binary
+  Add a b          -> w2 40 Add a b
+  Sub a b          -> w2 41 Sub a b
+  Mul a b          -> w2 42 Mul a b
+  Div a b          -> w2 43 Div a b
+  SDiv a b         -> w2 44 SDiv a b
+  Mod a b          -> w2 45 Mod a b
+  SMod a b         -> w2 46 SMod a b
+  Exp a b          -> w2 47 Exp a b
+  SEx a b          -> w2 48 SEx a b
+  Min a b          -> w2 49 Min a b
+  Max a b          -> w2 50 Max a b
+  LT a b           -> w2 51 LT a b
+  GT a b           -> w2 52 GT a b
+  LEq a b          -> w2 53 LEq a b
+  GEq a b          -> w2 54 GEq a b
+  SLT a b          -> w2 55 SLT a b
+  SGT a b          -> w2 56 SGT a b
+  Eq a b           -> w2 57 Eq a b
+  And a b          -> w2 58 And a b
+  Or a b           -> w2 59 Or a b
+  Xor a b          -> w2 60 Xor a b
+  SHL a b          -> w2 61 SHL a b
+  SHR a b          -> w2 62 SHR a b
+  SAR a b          -> w2 63 SAR a b
+  EqByte a b       -> do (a', ia) <- go a; (b', ib) <- go b; recanonW (64, P0, [ia, ib]) (EqByte a' b')
+  ReadWord a b     -> do (a', ia) <- go a; (b', ib) <- go b; recanonW (65, P0, [ia, ib]) (ReadWord a' b')
+  -- EWord ternary
+  AddMod a b c     -> w3 70 AddMod a b c
+  MulMod a b c     -> w3 71 MulMod a b c
+  ITE a b c        -> w3 72 ITE a b c
+  -- Byte
+  LitByte w        -> recanonBy (80, PB8 w, []) (LitByte w)
+  IndexWord a b    -> do (a', ia) <- go a; (b', ib) <- go b; recanonBy (81, P0, [ia, ib]) (IndexWord a' b')
+  ReadByte a b     -> do (a', ia) <- go a; (b', ib) <- go b; recanonBy (82, P0, [ia, ib]) (ReadByte a' b')
+  -- EAddr
+  SymAddr t        -> recanonA (90, PT t, []) (SymAddr t)
+  LitAddr a        -> recanonA (91, PAddr a, []) (LitAddr a)
+  -- Buffers
+  ConcreteBuf bs   -> recanonBu (100, PBS bs, []) (ConcreteBuf bs)
+  AbstractBuf t    -> recanonBu (101, PT t, []) (AbstractBuf t)
+  WriteWord a b c  -> do
+    (a', ia) <- go a; (b', ib) <- go b; (c', ic) <- go c
+    recanonBu (102, P0, [ia, ib, ic]) (WriteWord a' b' c')
+  WriteByte a b c  -> do
+    (a', ia) <- go a; (b', ib) <- go b; (c', ic) <- go c
+    recanonBu (103, P0, [ia, ib, ic]) (WriteByte a' b' c')
+  CopySlice a b c d e -> do
+    (a', ia) <- go a; (b', ib) <- go b; (c', ic) <- go c; (d', idd) <- go d; (e', ie) <- go e
+    recanonBu (104, P0, [ia, ib, ic, idd, ie]) (CopySlice a' b' c' d' e')
+  -- Storage
+  ConcreteStore m  -> recanonS (110, PStore (M.toList m), []) (ConcreteStore m)
+  AbstractStore a mw -> do
+    (a', ia) <- go a
+    recanonS (111, PMW mw, [ia]) (AbstractStore a' mw)
+  SLoad a b        -> do (a', ia) <- go a; (b', ib) <- go b; recanonW (112, P0, [ia, ib]) (SLoad a' b')
+  SStore a b c     -> do
+    (a', ia) <- go a; (b', ib) <- go b; (c', ic) <- go c
+    recanonS (113, P0, [ia, ib, ic]) (SStore a' b' c')
+  -- CSE variables (shared refs), keyed by their index
+  g@(GVar (BufVar n))   -> recanonBu (120, PInt n, []) g
+  g@(GVar (StoreVar n)) -> recanonS (121, PInt n, []) g
+  -- Everything else (JoinBytes, End/Log/EContract nodes): not structurally keyed.
+  e                -> freshOpaque e
+
+-- | Memoized structural map for repeatedly-applied simplification passes over hash-consed terms.
+-- Matches Traversals.mapExprM's f-application at every node, with three additions:
+--
+--   * the rewrite's output is interned, so a rewrite that rebuilds a structurally-equal node
+--     (e.g. via argument normalization) collapses back to the canonical object;
+--   * reconstruction is identity-preserving: when nothing changed, the ORIGINAL node is returned,
+--     so convergence is detectable by pointer identity in O(1) (see 'untilFixpoint');
+--   * canonical nodes that a pass has mapped to themselves are remembered per pass slot (an id
+--     set - no values are stored), so later applications skip them in O(1). On a shared DAG this
+--     turns each pass from O(logical size) into O(nodes not yet known to be fixpoints).
+--
+-- Sound for an f that is a pure function of node structure (all simplifier passes are). All
+-- results are forced before use: an unevaluated thunk never has the pointer identity of the
+-- node it evaluates to.
+memoFixTraverse :: Int -> (forall x. Expr x -> Expr x) -> Expr b -> Expr b
+memoFixTraverse slot f root = unsafePerformIO (goM root)
+  where
+    fi :: Expr x -> Expr x
+    fi x = internExpr (f x)
+
+    goM :: Expr x -> IO (Expr x)
+    goM n = do
+      mid <- lookupSN n
+      case (mid, tableFor n) of
+        (Just i, Just tab) -> do
+          memos <- readIORef passMemos
+          case IM.lookup i (tab.readT (IM.findWithDefault emptyMT slot memos)) of
+            Just r  -> pure r
+            Nothing -> do
+              r0 <- rb n
+              let !r = r0
+              atomicModifyIORef' passMemos $ \ms ->
+                let mt = IM.findWithDefault emptyMT slot ms
+                in (IM.insert slot (tab.writeT mt (IM.insert i r (tab.readT mt))) ms, ())
+              pure r
+        _ -> do
+          r0 <- rb n
+          let !r = r0
+          pure r
+
+    u0 :: Expr x -> IO (Expr x)
+    u0 orig = pure $! fi orig
+    u1 :: Expr x -> (Expr y -> Expr x) -> Expr y -> Expr y -> IO (Expr x)
+    u1 orig con a a' = pure $! fi (if ptrEq a' a then orig else con a')
+    u2 :: Expr x -> (Expr y -> Expr z -> Expr x) -> Expr y -> Expr z -> Expr y -> Expr z -> IO (Expr x)
+    u2 orig con a b a' b' = pure $! fi (if ptrEq a' a && ptrEq b' b then orig else con a' b')
+    u3 :: Expr x -> (Expr v -> Expr y -> Expr z -> Expr x)
+       -> Expr v -> Expr y -> Expr z -> Expr v -> Expr y -> Expr z -> IO (Expr x)
+    u3 orig con a b c a' b' c' =
+      pure $! fi (if ptrEq a' a && ptrEq b' b && ptrEq c' c then orig else con a' b' c')
+    u5 :: Expr x -> (Expr u -> Expr v -> Expr w -> Expr y -> Expr z -> Expr x)
+       -> Expr u -> Expr v -> Expr w -> Expr y -> Expr z
+       -> Expr u -> Expr v -> Expr w -> Expr y -> Expr z -> IO (Expr x)
+    u5 orig con a b c d e a' b' c' d' e' =
+      pure $! fi (if ptrEq a' a && ptrEq b' b && ptrEq c' c && ptrEq d' d && ptrEq e' e
+                  then orig else con a' b' c' d' e')
+
+    rb :: Expr x -> IO (Expr x)
+    rb orig = case orig of
+      Lit _ -> u0 orig
+      LitByte _ -> u0 orig
+      Var _ -> u0 orig
+      GVar _ -> u0 orig
+      C{} -> goEC orig
+      LitAddr _ -> u0 orig
+      SymAddr _ -> u0 orig
+      WAddr a -> do a' <- goM a; u1 orig WAddr a a'
+      IndexWord a b -> do a' <- goM a; b' <- goM b; u2 orig IndexWord a b a' b'
+      EqByte a b -> do a' <- goM a; b' <- goM b; u2 orig EqByte a b a' b'
+      JoinBytes b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15
+                b16 b17 b18 b19 b20 b21 b22 b23 b24 b25 b26 b27 b28 b29 b30 b31 -> do
+        let olds = [b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15
+                   ,b16,b17,b18,b19,b20,b21,b22,b23,b24,b25,b26,b27,b28,b29,b30,b31]
+        news <- mapM goM olds
+        case news of
+          [y0,y1,y2,y3,y4,y5,y6,y7,y8,y9,y10,y11,y12,y13,y14,y15
+           ,y16,y17,y18,y19,y20,y21,y22,y23,y24,y25,y26,y27,y28,y29,y30,y31] ->
+            pure $! fi (if and (zipWith ptrEq news olds) then orig
+                        else JoinBytes y0 y1 y2 y3 y4 y5 y6 y7 y8 y9 y10 y11 y12 y13 y14 y15
+                                       y16 y17 y18 y19 y20 y21 y22 y23 y24 y25 y26 y27 y28 y29 y30 y31)
+          _ -> internalError "memoFixTraverse: JoinBytes arity"
+      Failure a b c -> do
+        (a', sa) <- goPs a
+        pure $! fi (if sa then orig else Failure a' b c)
+      Partial a b c -> do
+        (a', sa) <- goPs a
+        pure $! fi (if sa then orig else Partial a' b c)
+      Success a b c d -> do
+        (a', sa) <- goPs a
+        c' <- goM c
+        kvs <- forM (M.toList d) $ \(k, v) -> do
+          k' <- goM k
+          v' <- goEC v
+          pure ((k', v'), ptrEq k' k && ptrEq v' v)
+        let sd = all snd kvs
+            d' = if sd then d else M.fromList (map fst kvs)
+        pure $! fi (if sa && ptrEq c' c && sd then orig else Success a' b c' d')
+      Add a b -> do a' <- goM a; b' <- goM b; u2 orig Add a b a' b'
+      Sub a b -> do a' <- goM a; b' <- goM b; u2 orig Sub a b a' b'
+      Mul a b -> do a' <- goM a; b' <- goM b; u2 orig Mul a b a' b'
+      Div a b -> do a' <- goM a; b' <- goM b; u2 orig Div a b a' b'
+      SDiv a b -> do a' <- goM a; b' <- goM b; u2 orig SDiv a b a' b'
+      Mod a b -> do a' <- goM a; b' <- goM b; u2 orig Mod a b a' b'
+      SMod a b -> do a' <- goM a; b' <- goM b; u2 orig SMod a b a' b'
+      AddMod a b c -> do a' <- goM a; b' <- goM b; c' <- goM c; u3 orig AddMod a b c a' b' c'
+      MulMod a b c -> do a' <- goM a; b' <- goM b; c' <- goM c; u3 orig MulMod a b c a' b' c'
+      Exp a b -> do a' <- goM a; b' <- goM b; u2 orig Exp a b a' b'
+      SEx a b -> do a' <- goM a; b' <- goM b; u2 orig SEx a b a' b'
+      Min a b -> do a' <- goM a; b' <- goM b; u2 orig Min a b a' b'
+      Max a b -> do a' <- goM a; b' <- goM b; u2 orig Max a b a' b'
+      LT a b -> do a' <- goM a; b' <- goM b; u2 orig LT a b a' b'
+      GT a b -> do a' <- goM a; b' <- goM b; u2 orig GT a b a' b'
+      LEq a b -> do a' <- goM a; b' <- goM b; u2 orig LEq a b a' b'
+      GEq a b -> do a' <- goM a; b' <- goM b; u2 orig GEq a b a' b'
+      SLT a b -> do a' <- goM a; b' <- goM b; u2 orig SLT a b a' b'
+      SGT a b -> do a' <- goM a; b' <- goM b; u2 orig SGT a b a' b'
+      Eq a b -> do a' <- goM a; b' <- goM b; u2 orig Eq a b a' b'
+      IsZero a -> do a' <- goM a; u1 orig IsZero a a'
+      ITE c t e -> do c' <- goM c; t' <- goM t; e' <- goM e; u3 orig ITE c t e c' t' e'
+      And a b -> do a' <- goM a; b' <- goM b; u2 orig And a b a' b'
+      Or a b -> do a' <- goM a; b' <- goM b; u2 orig Or a b a' b'
+      Xor a b -> do a' <- goM a; b' <- goM b; u2 orig Xor a b a' b'
+      Not a -> do a' <- goM a; u1 orig Not a a'
+      SHL a b -> do a' <- goM a; b' <- goM b; u2 orig SHL a b a' b'
+      SHR a b -> do a' <- goM a; b' <- goM b; u2 orig SHR a b a' b'
+      SAR a b -> do a' <- goM a; b' <- goM b; u2 orig SAR a b a' b'
+      CLZ a -> do a' <- goM a; u1 orig CLZ a a'
+      Keccak a -> do a' <- goM a; u1 orig Keccak a a'
+      Origin -> u0 orig
+      Coinbase -> u0 orig
+      Timestamp -> u0 orig
+      BlockNumber -> u0 orig
+      PrevRandao -> u0 orig
+      GasLimit -> u0 orig
+      ChainId -> u0 orig
+      BaseFee -> u0 orig
+      BlockHash a -> do a' <- goM a; u1 orig BlockHash a a'
+      TxValue -> u0 orig
+      Gas _ _ -> u0 orig
+      Balance a -> do a' <- goM a; u1 orig Balance a a'
+      CodeSize a -> do a' <- goM a; u1 orig CodeSize a a'
+      CodeHash a -> do a' <- goM a; u1 orig CodeHash a a'
+      LogEntry a b c -> do
+        a' <- goM a
+        b' <- goM b
+        c' <- mapM goM c
+        pure $! fi (if ptrEq a' a && ptrEq b' b && and (zipWith ptrEq c' c) then orig else LogEntry a' b' c')
+      ConcreteStore _ -> u0 orig
+      AbstractStore _ _ -> u0 orig
+      SLoad a b -> do a' <- goM a; b' <- goM b; u2 orig SLoad a b a' b'
+      SStore a b c -> do a' <- goM a; b' <- goM b; c' <- goM c; u3 orig SStore a b c a' b' c'
+      ConcreteBuf _ -> u0 orig
+      AbstractBuf _ -> u0 orig
+      ReadWord a b -> do a' <- goM a; b' <- goM b; u2 orig ReadWord a b a' b'
+      ReadByte a b -> do a' <- goM a; b' <- goM b; u2 orig ReadByte a b a' b'
+      WriteWord a b c -> do a' <- goM a; b' <- goM b; c' <- goM c; u3 orig WriteWord a b c a' b' c'
+      WriteByte a b c -> do a' <- goM a; b' <- goM b; c' <- goM c; u3 orig WriteByte a b c a' b' c'
+      CopySlice a b c d e -> do
+        a' <- goM a; b' <- goM b; c' <- goM c; d' <- goM d; e' <- goM e
+        u5 orig CopySlice a b c d e a' b' c' d' e'
+      BufLength a -> do a' <- goM a; u1 orig BufLength a a'
+
+    goPs :: [Prop] -> IO ([Prop], Bool)
+    goPs ps = do
+      ps' <- mapM goP ps
+      let same = and (zipWith ptrEq ps' ps)
+      pure (if same then (ps, True) else (ps', False))
+
+    goP :: Prop -> IO Prop
+    goP p = case p of
+      PBool _ -> pure p
+      PEq a b -> do a' <- goM a; b' <- goM b; pure $! (if ptrEq a' a && ptrEq b' b then p else PEq a' b')
+      PLT a b -> do a' <- goM a; b' <- goM b; pure $! (if ptrEq a' a && ptrEq b' b then p else PLT a' b')
+      PGT a b -> do a' <- goM a; b' <- goM b; pure $! (if ptrEq a' a && ptrEq b' b then p else PGT a' b')
+      PLEq a b -> do a' <- goM a; b' <- goM b; pure $! (if ptrEq a' a && ptrEq b' b then p else PLEq a' b')
+      PGEq a b -> do a' <- goM a; b' <- goM b; pure $! (if ptrEq a' a && ptrEq b' b then p else PGEq a' b')
+      PNeg a -> do a' <- goP a; pure $! (if ptrEq a' a then p else PNeg a')
+      PAnd a b -> do a' <- goP a; b' <- goP b; pure $! (if ptrEq a' a && ptrEq b' b then p else PAnd a' b')
+      POr a b -> do a' <- goP a; b' <- goP b; pure $! (if ptrEq a' a && ptrEq b' b then p else POr a' b')
+      PImpl a b -> do a' <- goP a; b' <- goP b; pure $! (if ptrEq a' a && ptrEq b' b then p else PImpl a' b')
+
+    goEC :: Expr EContract -> IO (Expr EContract)
+    goEC g@(GVar _) = pure g
+    goEC orig@(C code st tst bal n) = do
+      code' <- goCode code
+      st' <- goM st
+      tst' <- goM tst
+      bal' <- goM bal
+      pure $! (if ptrEq code' code && ptrEq st' st && ptrEq tst' tst && ptrEq bal' bal
+               then orig else C code' st' tst' bal' n)
+
+    goCode :: ContractCode -> IO ContractCode
+    goCode orig = case orig of
+      UnknownCode a -> do a' <- goM a; pure $! (if ptrEq a' a then orig else UnknownCode a')
+      RuntimeCode (ConcreteRuntimeCode _) -> pure orig
+      RuntimeCode (SymbolicRuntimeCode cs) -> do
+        cs' <- mapM goM cs
+        pure $! (if and (zipWith ptrEq (toList cs') (toList cs))
+                 then orig else RuntimeCode (SymbolicRuntimeCode cs'))
+      InitCode bs buf -> do buf' <- goM buf; pure $! (if ptrEq buf' buf then orig else InitCode bs buf')
+{-# NOINLINE memoFixTraverse #-}

--- a/src/EVM/HashCons.hs
+++ b/src/EVM/HashCons.hs
@@ -107,7 +107,10 @@ setHashConsEnabled = writeIORef hcEnabled
 
 resetHashCons :: IO ()
 resetHashCons = do
-  writeIORef hcState emptyHC
+  -- The id counter survives the reset: ids are never reused, so if another exploration is
+  -- still running (parallel test suites), its stale memo entries reference ids that no new
+  -- node can be assigned — a mid-run reset can only lose sharing, never correctness.
+  atomicModifyIORef' hcState $ \st -> (emptyHC { hcNext = st.hcNext }, ())
   writeIORef passMemos IM.empty
 
 -- | Per-pass memo of simplification results, keyed by canonical node id, with one table per

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -60,6 +60,7 @@ import EVM.Solvers (SolverGroup, checkSatWithProps)
 import EVM.Stepper (Stepper)
 import EVM.Stepper qualified as Stepper
 import EVM.Traversals (mapExpr, mapExprM, foldTerm)
+import EVM.HashCons qualified as HashCons
 import EVM.Types hiding (Comp)
 import EVM.Types qualified
 data LoopHeuristic
@@ -385,6 +386,11 @@ interpret :: forall m a . App m
 interpret fetcher iterConf vm stepper handler = do
   shouldAbort <- liftIO $ newTVarIO False
   conf <- readConfig
+  -- Construction-time hash-consing (EVM.HashCons): share structurally-identical subterms as they
+  -- are built, so deeply-reused symbolic terms stay DAGs instead of materializing as exponential
+  -- trees. Enabled per exploration; tables start clean.
+  liftIO $ do HashCons.setHashConsEnabled conf.hashConsExplore
+              HashCons.resetHashCons
   taskQ <- liftIO newChan
   processQ <- liftIO newChan
 

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -12,6 +12,7 @@ import Data.Foldable (Foldable(..))
 import Data.Map.Strict qualified as Map
 
 import EVM.Types
+import EVM.HashCons (internExpr, memoFixTraverse, hashConsEnabled)
 
 foldProp :: forall b . Monoid b => (forall a . Expr a -> b) -> b -> Prop -> b
 foldProp f acc p = acc <> (go p)
@@ -252,8 +253,20 @@ mapPropM' f = \case
     y <- mapPropM' f b
     f $ PImpl x y
 
+-- | internExpr shares each rebuilt node as it is produced (bottom-up, O(1) per node since children
+-- are already canonical), so passes built on mapExpr (notably Expr.simplify) never materialize the
+-- unshared exponential tree. It is a no-op unless hash-consing is enabled (EVM.HashCons).
 mapExpr :: (forall a . Expr a -> Expr a) -> Expr b -> Expr b
-mapExpr f expr = runIdentity (mapExprM (Identity . f) expr)
+mapExpr f expr = runIdentity (mapExprM (Identity . internExpr . f) expr)
+
+-- | Like 'mapExpr', for the repeatedly-applied simplification passes: when hash-consing is
+-- enabled, each distinct subterm is visited once and subterms already known to be fixpoints of
+-- this pass (identified by slot) are skipped in O(1). Falls back to plain mapExpr otherwise.
+mapExprShared :: Int -> (forall a . Expr a -> Expr a) -> Expr b -> Expr b
+mapExprShared slot f expr
+  | hashConsEnabled expr = memoFixTraverse slot f expr
+  | otherwise = runIdentity (mapExprM (Identity . f) expr)
+
 
 -- Like mapExprM but allows a function of type `Expr a -> m ()` to be passed
 mapExprM_ ::  Monad m => (forall a . Expr a -> m ()) -> Expr b -> m ()

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -14,6 +15,7 @@ module EVM.Types where
 import Prelude hiding (Foldable(..))
 
 import GHC.Stack (HasCallStack, prettyCallStack, callStack)
+import GHC.Exts (reallyUnsafePtrEquality#, isTrue#)
 import GHC.ByteOrder (targetByteOrder, ByteOrder(..))
 import Control.Arrow ((>>>))
 import Control.Monad (mzero)
@@ -387,8 +389,251 @@ data Expr (a :: EType) where
   BufLength      :: Expr Buf -> Expr EWord
 
 deriving instance Show (Expr a)
-deriving instance Eq (Expr a)
-deriving instance Ord (Expr a)
+
+-- The hand-written Eq/Ord instances below have semantics identical to the previously-derived
+-- ones (constructor declaration order, fields compared left-to-right), but every recursive
+-- comparison first checks physical identity. On hash-consed / shared terms (EVM.HashCons) this
+-- makes comparisons O(size of the differing part) instead of O(logical tree size), which removes
+-- the dominant cost of simplifier guards (a == b) and normalization compares on deeply-shared
+-- symbolic terms.
+
+-- | Constructor rank, mirroring declaration order so the hand-written Ord orders different
+-- constructors exactly as the derived instance did.
+exprRank :: Expr a -> Int
+exprRank = \case
+  Lit {} -> 0
+  Var {} -> 1
+  GVar {} -> 2
+  LitByte {} -> 3
+  IndexWord {} -> 4
+  EqByte {} -> 5
+  JoinBytes {} -> 6
+  Partial {} -> 7
+  Failure {} -> 8
+  Success {} -> 9
+  Add {} -> 10
+  Sub {} -> 11
+  Mul {} -> 12
+  Div {} -> 13
+  SDiv {} -> 14
+  Mod {} -> 15
+  SMod {} -> 16
+  AddMod {} -> 17
+  MulMod {} -> 18
+  Exp {} -> 19
+  SEx {} -> 20
+  Min {} -> 21
+  Max {} -> 22
+  EVM.Types.LT {} -> 23
+  EVM.Types.GT {} -> 24
+  LEq {} -> 25
+  GEq {} -> 26
+  SLT {} -> 27
+  SGT {} -> 28
+  Eq {} -> 29
+  IsZero {} -> 30
+  ITE {} -> 31
+  And {} -> 32
+  Or {} -> 33
+  Xor {} -> 34
+  Not {} -> 35
+  SHL {} -> 36
+  SHR {} -> 37
+  SAR {} -> 38
+  CLZ {} -> 39
+  Keccak {} -> 40
+  Origin -> 41
+  BlockHash {} -> 42
+  Coinbase -> 43
+  Timestamp -> 44
+  BlockNumber -> 45
+  PrevRandao -> 46
+  GasLimit -> 47
+  ChainId -> 48
+  BaseFee -> 49
+  TxValue -> 50
+  Balance {} -> 51
+  Gas {} -> 52
+  CodeSize {} -> 53
+  CodeHash {} -> 54
+  LogEntry {} -> 55
+  C {} -> 56
+  SymAddr {} -> 57
+  LitAddr {} -> 58
+  WAddr {} -> 59
+  ConcreteStore {} -> 60
+  AbstractStore {} -> 61
+  SLoad {} -> 62
+  SStore {} -> 63
+  ConcreteBuf {} -> 64
+  AbstractBuf {} -> 65
+  ReadWord {} -> 66
+  ReadByte {} -> 67
+  WriteWord {} -> 68
+  WriteByte {} -> 69
+  CopySlice {} -> 70
+  BufLength {} -> 71
+
+instance Eq (Expr a) where
+  x == y = ptrEq x y || go x y
+    where
+      eqSC :: Eq c => c -> c -> Bool
+      eqSC u v = ptrEq u v || u Prelude.== v
+      go :: Expr b -> Expr b -> Bool
+      go (Lit x0a) (Lit x0b) = eqSC x0a x0b
+      go (Var x0a) (Var x0b) = eqSC x0a x0b
+      go (GVar x0a) (GVar x0b) = eqSC x0a x0b
+      go (LitByte x0a) (LitByte x0b) = eqSC x0a x0b
+      go (IndexWord x0a x1a) (IndexWord x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (EqByte x0a x1a) (EqByte x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (JoinBytes x0a x1a x2a x3a x4a x5a x6a x7a x8a x9a x10a x11a x12a x13a x14a x15a x16a x17a x18a x19a x20a x21a x22a x23a x24a x25a x26a x27a x28a x29a x30a x31a) (JoinBytes x0b x1b x2b x3b x4b x5b x6b x7b x8b x9b x10b x11b x12b x13b x14b x15b x16b x17b x18b x19b x20b x21b x22b x23b x24b x25b x26b x27b x28b x29b x30b x31b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b && eqSC x3a x3b && eqSC x4a x4b && eqSC x5a x5b && eqSC x6a x6b && eqSC x7a x7b && eqSC x8a x8b && eqSC x9a x9b && eqSC x10a x10b && eqSC x11a x11b && eqSC x12a x12b && eqSC x13a x13b && eqSC x14a x14b && eqSC x15a x15b && eqSC x16a x16b && eqSC x17a x17b && eqSC x18a x18b && eqSC x19a x19b && eqSC x20a x20b && eqSC x21a x21b && eqSC x22a x22b && eqSC x23a x23b && eqSC x24a x24b && eqSC x25a x25b && eqSC x26a x26b && eqSC x27a x27b && eqSC x28a x28b && eqSC x29a x29b && eqSC x30a x30b && eqSC x31a x31b
+      go (Partial x0a x1a x2a) (Partial x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (Failure x0a x1a x2a) (Failure x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (Success x0a x1a x2a x3a) (Success x0b x1b x2b x3b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b && eqSC x3a x3b
+      go (Add x0a x1a) (Add x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Sub x0a x1a) (Sub x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Mul x0a x1a) (Mul x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Div x0a x1a) (Div x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SDiv x0a x1a) (SDiv x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Mod x0a x1a) (Mod x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SMod x0a x1a) (SMod x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (AddMod x0a x1a x2a) (AddMod x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (MulMod x0a x1a x2a) (MulMod x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (Exp x0a x1a) (Exp x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SEx x0a x1a) (SEx x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Min x0a x1a) (Min x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Max x0a x1a) (Max x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (EVM.Types.LT x0a x1a) (EVM.Types.LT x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (EVM.Types.GT x0a x1a) (EVM.Types.GT x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (LEq x0a x1a) (LEq x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (GEq x0a x1a) (GEq x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SLT x0a x1a) (SLT x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SGT x0a x1a) (SGT x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Eq x0a x1a) (Eq x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (IsZero x0a) (IsZero x0b) = eqSC x0a x0b
+      go (ITE x0a x1a x2a) (ITE x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (And x0a x1a) (And x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Or x0a x1a) (Or x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Xor x0a x1a) (Xor x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (Not x0a) (Not x0b) = eqSC x0a x0b
+      go (SHL x0a x1a) (SHL x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SHR x0a x1a) (SHR x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SAR x0a x1a) (SAR x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (CLZ x0a) (CLZ x0b) = eqSC x0a x0b
+      go (Keccak x0a) (Keccak x0b) = eqSC x0a x0b
+      go Origin Origin = True
+      go (BlockHash x0a) (BlockHash x0b) = eqSC x0a x0b
+      go Coinbase Coinbase = True
+      go Timestamp Timestamp = True
+      go BlockNumber BlockNumber = True
+      go PrevRandao PrevRandao = True
+      go GasLimit GasLimit = True
+      go ChainId ChainId = True
+      go BaseFee BaseFee = True
+      go TxValue TxValue = True
+      go (Balance x0a) (Balance x0b) = eqSC x0a x0b
+      go (Gas x0a x1a) (Gas x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (CodeSize x0a) (CodeSize x0b) = eqSC x0a x0b
+      go (CodeHash x0a) (CodeHash x0b) = eqSC x0a x0b
+      go (LogEntry x0a x1a x2a) (LogEntry x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (C x0a x1a x2a x3a x4a) (C x0b x1b x2b x3b x4b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b && eqSC x3a x3b && eqSC x4a x4b
+      go (SymAddr x0a) (SymAddr x0b) = eqSC x0a x0b
+      go (LitAddr x0a) (LitAddr x0b) = eqSC x0a x0b
+      go (WAddr x0a) (WAddr x0b) = eqSC x0a x0b
+      go (ConcreteStore x0a) (ConcreteStore x0b) = eqSC x0a x0b
+      go (AbstractStore x0a x1a) (AbstractStore x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SLoad x0a x1a) (SLoad x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (SStore x0a x1a x2a) (SStore x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (ConcreteBuf x0a) (ConcreteBuf x0b) = eqSC x0a x0b
+      go (AbstractBuf x0a) (AbstractBuf x0b) = eqSC x0a x0b
+      go (ReadWord x0a x1a) (ReadWord x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (ReadByte x0a x1a) (ReadByte x0b x1b) = eqSC x0a x0b && eqSC x1a x1b
+      go (WriteWord x0a x1a x2a) (WriteWord x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (WriteByte x0a x1a x2a) (WriteByte x0b x1b x2b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b
+      go (CopySlice x0a x1a x2a x3a x4a) (CopySlice x0b x1b x2b x3b x4b) = eqSC x0a x0b && eqSC x1a x1b && eqSC x2a x2b && eqSC x3a x3b && eqSC x4a x4b
+      go (BufLength x0a) (BufLength x0b) = eqSC x0a x0b
+      go _ _ = False
+
+instance Ord (Expr a) where
+  compare x y = if ptrEq x y then Prelude.EQ else go x y
+    where
+      cmpSC :: Ord c => c -> c -> Ordering
+      cmpSC u v = if ptrEq u v then Prelude.EQ else Prelude.compare u v
+      go :: Expr b -> Expr b -> Ordering
+      go (Lit x0a) (Lit x0b) = cmpSC x0a x0b
+      go (Var x0a) (Var x0b) = cmpSC x0a x0b
+      go (GVar x0a) (GVar x0b) = cmpSC x0a x0b
+      go (LitByte x0a) (LitByte x0b) = cmpSC x0a x0b
+      go (IndexWord x0a x1a) (IndexWord x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (EqByte x0a x1a) (EqByte x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (JoinBytes x0a x1a x2a x3a x4a x5a x6a x7a x8a x9a x10a x11a x12a x13a x14a x15a x16a x17a x18a x19a x20a x21a x22a x23a x24a x25a x26a x27a x28a x29a x30a x31a) (JoinBytes x0b x1b x2b x3b x4b x5b x6b x7b x8b x9b x10b x11b x12b x13b x14b x15b x16b x17b x18b x19b x20b x21b x22b x23b x24b x25b x26b x27b x28b x29b x30b x31b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b Prelude.<> cmpSC x3a x3b Prelude.<> cmpSC x4a x4b Prelude.<> cmpSC x5a x5b Prelude.<> cmpSC x6a x6b Prelude.<> cmpSC x7a x7b Prelude.<> cmpSC x8a x8b Prelude.<> cmpSC x9a x9b Prelude.<> cmpSC x10a x10b Prelude.<> cmpSC x11a x11b Prelude.<> cmpSC x12a x12b Prelude.<> cmpSC x13a x13b Prelude.<> cmpSC x14a x14b Prelude.<> cmpSC x15a x15b Prelude.<> cmpSC x16a x16b Prelude.<> cmpSC x17a x17b Prelude.<> cmpSC x18a x18b Prelude.<> cmpSC x19a x19b Prelude.<> cmpSC x20a x20b Prelude.<> cmpSC x21a x21b Prelude.<> cmpSC x22a x22b Prelude.<> cmpSC x23a x23b Prelude.<> cmpSC x24a x24b Prelude.<> cmpSC x25a x25b Prelude.<> cmpSC x26a x26b Prelude.<> cmpSC x27a x27b Prelude.<> cmpSC x28a x28b Prelude.<> cmpSC x29a x29b Prelude.<> cmpSC x30a x30b Prelude.<> cmpSC x31a x31b
+      go (Partial x0a x1a x2a) (Partial x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (Failure x0a x1a x2a) (Failure x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (Success x0a x1a x2a x3a) (Success x0b x1b x2b x3b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b Prelude.<> cmpSC x3a x3b
+      go (Add x0a x1a) (Add x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Sub x0a x1a) (Sub x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Mul x0a x1a) (Mul x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Div x0a x1a) (Div x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SDiv x0a x1a) (SDiv x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Mod x0a x1a) (Mod x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SMod x0a x1a) (SMod x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (AddMod x0a x1a x2a) (AddMod x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (MulMod x0a x1a x2a) (MulMod x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (Exp x0a x1a) (Exp x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SEx x0a x1a) (SEx x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Min x0a x1a) (Min x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Max x0a x1a) (Max x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (EVM.Types.LT x0a x1a) (EVM.Types.LT x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (EVM.Types.GT x0a x1a) (EVM.Types.GT x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (LEq x0a x1a) (LEq x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (GEq x0a x1a) (GEq x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SLT x0a x1a) (SLT x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SGT x0a x1a) (SGT x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Eq x0a x1a) (Eq x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (IsZero x0a) (IsZero x0b) = cmpSC x0a x0b
+      go (ITE x0a x1a x2a) (ITE x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (And x0a x1a) (And x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Or x0a x1a) (Or x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Xor x0a x1a) (Xor x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (Not x0a) (Not x0b) = cmpSC x0a x0b
+      go (SHL x0a x1a) (SHL x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SHR x0a x1a) (SHR x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SAR x0a x1a) (SAR x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (CLZ x0a) (CLZ x0b) = cmpSC x0a x0b
+      go (Keccak x0a) (Keccak x0b) = cmpSC x0a x0b
+      go Origin Origin = Prelude.EQ
+      go (BlockHash x0a) (BlockHash x0b) = cmpSC x0a x0b
+      go Coinbase Coinbase = Prelude.EQ
+      go Timestamp Timestamp = Prelude.EQ
+      go BlockNumber BlockNumber = Prelude.EQ
+      go PrevRandao PrevRandao = Prelude.EQ
+      go GasLimit GasLimit = Prelude.EQ
+      go ChainId ChainId = Prelude.EQ
+      go BaseFee BaseFee = Prelude.EQ
+      go TxValue TxValue = Prelude.EQ
+      go (Balance x0a) (Balance x0b) = cmpSC x0a x0b
+      go (Gas x0a x1a) (Gas x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (CodeSize x0a) (CodeSize x0b) = cmpSC x0a x0b
+      go (CodeHash x0a) (CodeHash x0b) = cmpSC x0a x0b
+      go (LogEntry x0a x1a x2a) (LogEntry x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (C x0a x1a x2a x3a x4a) (C x0b x1b x2b x3b x4b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b Prelude.<> cmpSC x3a x3b Prelude.<> cmpSC x4a x4b
+      go (SymAddr x0a) (SymAddr x0b) = cmpSC x0a x0b
+      go (LitAddr x0a) (LitAddr x0b) = cmpSC x0a x0b
+      go (WAddr x0a) (WAddr x0b) = cmpSC x0a x0b
+      go (ConcreteStore x0a) (ConcreteStore x0b) = cmpSC x0a x0b
+      go (AbstractStore x0a x1a) (AbstractStore x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SLoad x0a x1a) (SLoad x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (SStore x0a x1a x2a) (SStore x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (ConcreteBuf x0a) (ConcreteBuf x0b) = cmpSC x0a x0b
+      go (AbstractBuf x0a) (AbstractBuf x0b) = cmpSC x0a x0b
+      go (ReadWord x0a x1a) (ReadWord x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (ReadByte x0a x1a) (ReadByte x0b x1b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b
+      go (WriteWord x0a x1a x2a) (WriteWord x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (WriteByte x0a x1a x2a) (WriteByte x0b x1b x2b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b
+      go (CopySlice x0a x1a x2a x3a x4a) (CopySlice x0b x1b x2b x3b x4b) = cmpSC x0a x0b Prelude.<> cmpSC x1a x1b Prelude.<> cmpSC x2a x2b Prelude.<> cmpSC x3a x3b Prelude.<> cmpSC x4a x4b
+      go (BufLength x0a) (BufLength x0b) = cmpSC x0a x0b
+      go l r = Prelude.compare (exprRank l) (exprRank r)
+
 
 
 -- Existential Wrapper -----------------------------------------------------------------------------
@@ -1650,12 +1895,23 @@ paddedShowHex w n = pad ++ str
      str = showHex n ""
      pad = replicate (w - length str) '0'
 
+
+-- | Pointer equality. Sound as a fast-path before structural (==): a True result means the two
+-- values are the same heap object (hence equal); a False result falls through to structural ==.
+ptrEq :: a -> a -> Bool
+ptrEq x y = isTrue# (reallyUnsafePtrEquality# x y)
+
 untilFixpoint :: Eq a => (a -> a) -> a -> a
-untilFixpoint f a =
-  let a' = f a in
-    if a' == a
-    then a
-    else untilFixpoint f a'
+untilFixpoint f a0 = go a0
+  where
+    -- ptrEq short-circuits the common "f made no change" case: an identity-preserving f (see
+    -- EVM.HashCons.memoFixTraverse) returns the *same object* on convergence, detected in O(1)
+    -- instead of an O(term-size) structural comparison.
+    -- a' must be forced before ptrEq: comparing an unevaluated thunk against the input is always
+    -- False even when the thunk evaluates to the very same object, silently defeating the fast path.
+    go a =
+      let !a' = f a
+      in if ptrEq a' a || a' == a then a else go a'
 
 bsToHex :: ByteString -> String
 bsToHex bs = concatMap (paddedShowHex 2) (BS.unpack bs)

--- a/test/BlockchainTests.hs
+++ b/test/BlockchainTests.hs
@@ -5,7 +5,7 @@ import EVM.Effects
 import EVM.Test.BlockchainTests qualified as BlockchainTests
 
 testEnv :: Env
-testEnv = Env { config = defaultConfig }
+testEnv = Env { config = defaultConfig { hashConsExplore = True } }
 
 main :: IO ()
 main = do

--- a/test/ForgeSymbolicTestSuite.hs
+++ b/test/ForgeSymbolicTestSuite.hs
@@ -75,7 +75,8 @@ runCase getRoot fn = do
   root <- getRoot
   (_, out, err) <- readProcessWithExitCode "cabal"
     [ "run", "-v0", "exe:hevm", "--", "test", "--root", root
-    , "--prefix", "check", "--match", fn, "--solver", "bitwuzla", "--max-iterations", "100" ] ""
+    , "--prefix", "check", "--match", fn, "--solver", "bitwuzla", "--max-iterations", "100"
+    , "--hash-cons" ] ""
   let report = "\n--- stdout ---\n" <> out <> "\n--- stderr ---\n" <> err
   assertBool ("no validated counterexample for " <> fn <> report)
     ("[FAIL]" `isInfixOf` out && "validated" `isInfixOf` out)

--- a/test/clitest.hs
+++ b/test/clitest.hs
@@ -33,6 +33,9 @@ testEnv = Env { config = defaultConfig {
   , dumpTrace = False
   , decomposeStorage = True
   , verb = 1
+  -- run the whole suite with hash-consing on so the sharing machinery is
+  -- exercised everywhere; it stays off by default outside the tests
+  , hashConsExplore = True
   } }
 
 runForge :: FilePath -> [String] -> IO (ExitCode, String, String)

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -28,7 +28,7 @@ import Control.Monad.IO.Unlift
 import EVM.Effects
 
 rpcEnv :: Env
-rpcEnv = Env { config = defaultConfig }
+rpcEnv = Env { config = defaultConfig { hashConsExplore = True } }
 
 test :: TestName -> ReaderT Env IO () -> TestTree
 test a b = testCase a $ runEnv rpcEnv b

--- a/test/test.hs
+++ b/test/test.hs
@@ -82,6 +82,9 @@ testEnv = Env { config = defaultConfig {
   , dumpTrace = False
   , decomposeStorage = True
   , verb = 1
+  -- run the whole suite with hash-consing on so the sharing machinery is
+  -- exercised everywhere; it stays off by default outside the tests
+  , hashConsExplore = True
   } }
 
 putStrLnM :: (MonadUnliftIO m) => String -> m ()


### PR DESCRIPTION
## Description

The symbolic interpreter rebuilds structurally-identical subterms as separate heap objects (e.g. a mapping-slot keccak recomputed on every storage access), so a computation that reuses an intermediate at k nesting levels materializes a 2^k tree with no sharing. On storage-heavy targets this exhausts memory: in one observed case a 914-node DAG materialized as a 601,664-node tree with a 22 GB peak, and every structural traversal or comparison pays the logical (not the shared) size.

This PR adds an experimental, off-by-default fix:

* **New `EVM.HashCons` module** — `internExpr` returns a canonical representative per structural equivalence class, so the heap holds the DAG, not the tree. It is exact (never merges structurally-different terms) and O(1) amortized per node: a `StableName` table shortcuts already-canonical nodes, and the structural tables are keyed by shallow keys (constructor tag, scalar payload, child ids), so lookups never compare whole subterms. Interning hooks sit at the term-construction sites: stack ops, the SLOAD/keccak paths, and `mapExpr` rebuilds.
* **Pointer-equality fast paths** — `Expr`'s `Eq`/`Ord` instances are now hand-written with a `ptrEq` shortcut at every recursive step. Semantics are identical to the previously-derived instances (constructor declaration order, fields left-to-right); on shared terms comparisons drop from O(logical size) to O(size of the differing part), which removes the dominant cost of simplifier guards (`a == b`) and normalization compares.
* **Memoized simplifier passes** — `untilFixpoint` detects convergence by pointer identity, and the repeatedly-applied passes (`litToKeccak`, `simplifyNoLitToKeccak`, `concKeccakSimpExpr` via `mapExprShared`/`memoFixTraverse`) remember per-node fixpoint status per pass, skipping already-simplified shared subterms in O(1).
* **`readStorage` fast path** — two distinct literal slots can never alias, so reads skip down concrete `SStore` chains without invoking the simplifier through `surelyEqual`/`surelyNotEqual`.

Everything is gated behind the new `hashConsExplore` config flag (default `False`): when disabled, every hook is a single `IORef` read returning its argument unchanged, so existing behavior is untouched. The intern tables are module-global in the style of GHC's FastString table and are reset at the start of each symbolic exploration; the id counter survives resets, so overlapping explorations (parallel test cases) can only lose sharing, never correctness.

`internExpr e` is always structurally equal to `e` — it only shares memory — so enabling the flag cannot change verification results, only their cost.

**CLI & tests:** the flag is exposed as `--hash-cons`, and all test suites (`test`, `cli`, `BlockchainTests`, `rpc`, and the `forge-symbolic-tests` runner) run with hash-consing enabled, so the sharing machinery is exercised by the entire suite while remaining opt-in for users.

## Checklist

- [x] tested the changes locally (builds clean; exercised via echidna verification mode on storage-heavy targets)
- [x] added changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)