### PR TITLE
Add message overloads for boolean assertions

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2163,28 +2163,8 @@ cheatActions = Map.fromList
   , $(envReadMultipleCheat "envBytes32(string,string)" $ AbiBytesType 32) stringToBytes32
   , $(envReadMultipleCheat "envString(string,string)" AbiStringType) stringToByteString
   , $(envReadMultipleCheat "envBytes(bytes,bytes)" AbiBytesDynamicType) stringHexToByteString
-  , action "assertTrue(bool)" $ \sig input ->
-      case decodeBuf [AbiBoolType] input of
-        (CAbi [AbiBool True],"") -> doStop
-        (CAbi [AbiBool False],"") -> frameRevert "assertion failed"
-        (SAbi [eword],"") -> case (Expr.simplify (Expr.iszero eword)) of
-          Lit 1 -> frameRevert "assertion failed"
-          Lit 0 -> doStop
-          ew -> branch (?conf).maxDepth ew $ \case
-            True -> frameRevert "assertion failed"
-            False -> doStop
-        k -> vmError $ BadCheatCode ("assertTrue(bool) parameter decoding failed: " <> show k) sig
-  , action "assertFalse(bool)" $ \sig input ->
-      case decodeBuf [AbiBoolType] input of
-        (CAbi [AbiBool False],"") -> doStop
-        (CAbi [AbiBool True],"") -> frameRevert "assertion failed"
-        (SAbi [eword],"") -> case (Expr.simplify (Expr.iszero eword)) of
-          Lit 0 -> frameRevert "assertion failed"
-          Lit 1 -> doStop
-          ew -> branch (?conf).maxDepth ew $ \case
-            False -> frameRevert "assertion failed"
-            True -> doStop
-        k -> vmError $ BadCheatCode ("assertFalse(bool) parameter decoding failed: " <> show k) sig
+  , action "assertTrue(bool)" $ assertTrue
+  , action "assertFalse(bool)" $ assertFalse
   , action "assertEq(bool,bool)"       $ assertEq AbiBoolType
   , action "assertEq(uint256,uint256)" $ assertEq (AbiUIntType 256)
   , action "assertEq(int256,int256)"   $ assertEq (AbiIntType 256)
@@ -2218,6 +2198,9 @@ cheatActions = Map.fromList
   --
   -- Variants with a trailing `err` string. The string is decoded away and never
   -- used; each behaves exactly like its non-message counterpart.
+  , action "assertTrue(bool,string)" $ withMsg 1 assertTrue
+  , action "assertFalse(bool,string)" $ withMsg 1 assertFalse
+  --
   , action "assertEq(bool,bool,string)"       $ withMsg 2 (assertEq AbiBoolType)
   , action "assertEq(uint256,uint256,string)" $ withMsg 2 (assertEq (AbiUIntType 256))
   , action "assertEq(int256,int256,string)"   $ withMsg 2 (assertEq (AbiIntType 256))
@@ -2271,6 +2254,28 @@ cheatActions = Map.fromList
       assign #result Nothing
       cont
     doStop = finishFrame (FrameReturned mempty)
+    assertTrue sig input =
+      case decodeBuf [AbiBoolType] input of
+        (CAbi [AbiBool True],"") -> doStop
+        (CAbi [AbiBool False],"") -> frameRevert "assertion failed"
+        (SAbi [eword],"") -> case (Expr.simplify (Expr.iszero eword)) of
+          Lit 1 -> frameRevert "assertion failed"
+          Lit 0 -> doStop
+          ew -> branch (?conf).maxDepth ew $ \case
+            True -> frameRevert "assertion failed"
+            False -> doStop
+        k -> vmError $ BadCheatCode ("assertTrue(bool) parameter decoding failed: " <> show k) sig
+    assertFalse sig input =
+      case decodeBuf [AbiBoolType] input of
+        (CAbi [AbiBool False],"") -> doStop
+        (CAbi [AbiBool True],"") -> frameRevert "assertion failed"
+        (SAbi [eword],"") -> case (Expr.simplify (Expr.iszero eword)) of
+          Lit 0 -> frameRevert "assertion failed"
+          Lit 1 -> doStop
+          ew -> branch (?conf).maxDepth ew $ \case
+            False -> frameRevert "assertion failed"
+            True -> doStop
+        k -> vmError $ BadCheatCode ("assertFalse(bool) parameter decoding failed: " <> show k) sig
     -- ABI strings are raw bytes with no enforced encoding, so decode
     -- leniently: invalid UTF-8 must not crash cheatcode handling (#1076)
     toString = unpack . decodeUtf8With lenientDecode

--- a/test/contracts/fail/assertMsg.sol
+++ b/test/contracts/fail/assertMsg.sol
@@ -6,6 +6,14 @@ import "forge-std/Test.sol";
 // hevm's handler (withMsg / keepHeadWords / assertEqMsgDyn). A broken decode
 // would surface as a BadCheatCode error instead of a clean assertion failure.
 contract AssertMsgFailTest is Test {
+    function prove_true_msg() public pure {
+        vm.assertTrue(false, "bool true");
+    }
+
+    function prove_false_msg() public pure {
+        vm.assertFalse(true, "bool false");
+    }
+
     // --- assertEq(...,string): static operands (withMsg) ---
 
     function prove_eq_bool_msg() public pure {

--- a/test/contracts/pass/assertMsg.sol
+++ b/test/contracts/pass/assertMsg.sol
@@ -3,9 +3,17 @@ import "forge-std/Test.sol";
 // Passing counterparts of the new message-bearing and bytes assert overloads.
 // For most overloads forge-std short-circuits on the passing branch and never
 // reaches the cheatcode, so these mainly guard against compile/behaviour
-// regressions; the assertApproxEq{Abs,Rel}(...,string) overloads forward to the
-// cheatcode unconditionally and therefore exercise hevm's handler here too.
+// regressions. The direct boolean calls below and the
+// assertApproxEq{Abs,Rel}(...,string) overloads exercise hevm's handlers here.
 contract AssertMsgPassTest is Test {
+    function prove_true_msg() public pure {
+        vm.assertTrue(true, "bool true");
+    }
+
+    function prove_false_msg() public pure {
+        vm.assertFalse(false, "bool false");
+    }
+
     function prove_eq_bool_msg() public pure {
         assertEq(true, true, "bool eq");
     }


### PR DESCRIPTION
## Description

Added support for `assertTrue(bool,string)` and `assertFalse(bool,string)`.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
