### PR TITLE
Test Foundry methods independently

### DIFF
--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -120,7 +120,13 @@ makeVeriOpts opts =
 -- | Top level CLI endpoint for hevm test
 -- | Returns tuple of (No Cex, No warnings)
 unitTest :: App m => UnitTestOptions -> BuildOutput -> m (Bool, Bool)
-unitTest opts bo@(BuildOutput (Contracts cs) _) = do
+unitTest opts bo = do
+  results <- unitTestResults opts bo
+  let (firsts, seconds) = unzip results
+  pure (and firsts, and seconds)
+
+unitTestResults :: App m => UnitTestOptions -> BuildOutput -> m [(Bool, Bool)]
+unitTestResults opts bo@(BuildOutput (Contracts cs) _) = do
   let unitTestContrs = [(c, methods) | c <- Map.elems cs, let methods = findUnitTests opts.methodFilter c, not (null methods)]
   conf <- readConfig
   when conf.debug $ liftIO $ do
@@ -128,8 +134,7 @@ unitTest opts bo@(BuildOutput (Contracts cs) _) = do
     let x = map (\(a,b) -> "  --> " <> a.contractName <> "  ---  functions: " <> (Text.pack $ show b)) unitTestContrs
     putStrLn $ unlines $ map Text.unpack x
   results <- mapM (runUnitTestContract opts bo) unitTestContrs
-  let (firsts, seconds) = unzip $ concat results
-  pure (and firsts, and seconds)
+  pure $ concat results
 
 -- | Assuming a constructor is loaded, this stepper will run the constructor
 -- to create the test contract, give it an initial balance, and run `setUp()'.

--- a/test/EVM/Test/FoundryTests.hs
+++ b/test/EVM/Test/FoundryTests.hs
@@ -9,10 +9,10 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import EVM.ABI (Sig(..))
-import EVM.Dapp (TestMethodInfo(..))
+import EVM.Dapp (TestMethodFilter, TestMethodInfo(..))
 import EVM.Effects
 import EVM.Fetch qualified as Fetch
-import EVM.Test.Utils (runForgeTest, runForgeTestCustom)
+import EVM.Test.Utils (runForgeTest, runForgeTestResults, runForgeTestResultsCustom)
 import EVM.Types (regexMatches)
 
 foundryTestConfig :: Config
@@ -66,23 +66,22 @@ tests = testGroup "Foundry tests"
               , ("test/contracts/fail/etchFail.sol",      "prove_etch_fail.*", (False, True))
               ]
         forM_ cases $ \(testFile, match, expected) -> do
-          actual <- executeTestMethodsMatching testFile match
-          assertEqualM "Must match" expected actual
+          assertAllTestMethodsMatching testFile match expected
     , test "Trivial-Fail" $ do
         let testFile = "test/contracts/fail/trivial.sol"
         executeSingleMethod testFile "prove_false" >>= assertEqualM "test result" (False, False)
     , test "Abstract" $ do
         let testFile = "test/contracts/pass/abstract.sol"
-        executeAllMethodsWithPrefix testFile "test" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "test" (True, True)
     , test "Constantinople" $ do
         let testFile = "test/contracts/pass/constantinople.sol"
-        executeAllMethodsWithPrefix testFile "check_" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "check_" (True, True)
     , test "Fusaka" $ do
         let testFile = "test/contracts/pass/fusaka.sol"
-        executeAllMethodsWithPrefix testFile "check_" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "check_" (True, True)
     , test "Prove-Tests-Pass" $ do
         let testFile = "test/contracts/pass/dsProvePass.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "prove" (True, True)
     , test "prefix-check" $ do
         let testFile = "test/contracts/fail/check-prefix.sol"
         executeSingleMethod testFile "check_trivial" >>= assertEqualM "test result" (False, False)
@@ -98,29 +97,31 @@ tests = testGroup "Foundry tests"
         executeSingleMethod testFile "prove_trivial" >>= assertEqualM "prove_trivial" (False, False)
         executeSingleMethod testFile "prove_trivial_dstest" >>= assertEqualM "prove_trivial_dstest" (False, False)
         executeSingleMethod testFile "prove_add" >>= assertEqualM "prove_add" (False, True)
-        runForgeTestCustom testFile (\(TestMethodInfo _ (Sig name _)) -> regexMatches "prove_smtTimeout" name) (Just 1) Nothing False Fetch.noRpc
-          >>= assertEqualM "prove_smtTimeout" (True, False)
+        runForgeTestResultsCustom testFile (\(TestMethodInfo _ (Sig name _)) -> name == "prove_smtTimeout") (Just 1) Nothing False Fetch.noRpc
+          >>= assertEqualM "prove_smtTimeout" [(True, False)]
         executeSingleMethod testFile "prove_multi" >>= assertEqualM "prove_multi" (False, True)
         executeSingleMethod testFile "prove_distributivity" >>= assertEqualM "prove_distributivity" (False, True)
     , test "Loop-Tests" $ do
         let testFile = "test/contracts/pass/loops.sol"
-        runForgeTestCustom testFile (\(TestMethodInfo _ (Sig name _)) -> regexMatches "prove_loop" name) Nothing (Just 10) False Fetch.noRpc  >>= assertEqualM "test result" (True, False)
-        runForgeTestCustom testFile (\(TestMethodInfo _ (Sig name _)) -> regexMatches "prove_loop" name) Nothing (Just 100) False Fetch.noRpc >>= assertEqualM "test result" (False, False)
+        runForgeTestResultsCustom testFile (\(TestMethodInfo _ (Sig name _)) -> name == "prove_loop") Nothing (Just 10) False Fetch.noRpc
+          >>= assertEqualM "test result" [(True, False)]
+        runForgeTestResultsCustom testFile (\(TestMethodInfo _ (Sig name _)) -> name == "prove_loop") Nothing (Just 100) False Fetch.noRpc
+          >>= assertEqualM "test result" [(False, False)]
     , test "Cheat-Codes-Pass" $ do
         let testFile = "test/contracts/pass/cheatCodes.sol"
         executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, False)
     , test "Expect-Revert-Pass" $ do
         let testFile = "test/contracts/pass/expectRevert.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "prove" (True, True)
     , test "Expect-Revert-Fail" $ do
         let testFile = "test/contracts/fail/expectRevert.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (False, True)
+        assertAllMethodsWithPrefix testFile "prove" (False, True)
     , test "Cheat-Codes-Fork-Pass" $ do
         let testFile = "test/contracts/pass/cheatCodesFork.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "prove" (True, True)
     , test "Unwind" $ do
         let testFile = "test/contracts/pass/unwind.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "prove" (True, True)
     , test "Keccak" $ do
         let testFile = "test/contracts/pass/keccak.sol"
         executeSingleMethod testFile "prove_access" >>= assertEqualM "test result" (True, True)
@@ -135,7 +136,7 @@ tests = testGroup "Foundry tests"
         executeSingleMethod testFile "prove_same_mapping_falsifiable" >>= assertEqualM "same-mapping read must falsify" (False, True)
     , test "AssertApproxEqAbs-Pass" $ do
         let testFile = "test/contracts/pass/assertApproxEqAbs.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "prove" (True, True)
     , test "AssertApproxEqAbs-Fail" $ do
         let testFile = "test/contracts/fail/assertApproxEqAbs.sol"
         let cases =
@@ -151,7 +152,7 @@ tests = testGroup "Foundry tests"
           executeSingleMethod testFile method >>= assertEqualM (unpack method) expected
     , test "AssertApproxEqRel-Pass" $ do
         let testFile = "test/contracts/pass/assertApproxEqRel.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "prove" (True, True)
     , test "AssertApproxEqRel-Fail" $ do
         let testFile = "test/contracts/fail/assertApproxEqRel.sol"
         let cases =
@@ -168,12 +169,12 @@ tests = testGroup "Foundry tests"
           executeSingleMethod testFile method >>= assertEqualM (unpack method) expected
     , test "AssertMsg-Pass" $ do
         let testFile = "test/contracts/pass/assertMsg.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+        assertAllMethodsWithPrefix testFile "prove" (True, True)
     , test "AssertMsg-Fail" $ do
         -- every message/bytes overload is violated; all concrete, so all branches
         -- revert -> (False, False)
         let testFile = "test/contracts/fail/assertMsg.sol"
-        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (False, False)
+        assertAllMethodsWithPrefix testFile "prove" (False, False)
     , test "Panic-Source-Location" $ do
         -- Regression test for #895: panic in a called contract should not show "<source not found>"
         let testFile = "test/contracts/fail/assertPanic.sol"
@@ -181,10 +182,27 @@ tests = testGroup "Foundry tests"
     ]
 
 executeSingleMethod :: (App m, MonadMask m) => FilePath -> Text -> m (Bool, Bool)
-executeSingleMethod file methodName = runForgeTest file (\(TestMethodInfo _ (Sig name _)) -> regexMatches methodName name)
+executeSingleMethod file methodName = do
+  results <- runForgeTestResults file (\(TestMethodInfo _ (Sig name _)) -> name == methodName)
+  case results of
+    [result] -> pure result
+    _ -> do
+      _ <- liftIO $ assertFailure ("expected exactly one method named " <> unpack methodName <> ", got " <> show (length results))
+      pure (True, True)
 
 executeAllMethodsWithPrefix :: (App m, MonadMask m) => FilePath -> Text -> m (Bool, Bool)
 executeAllMethodsWithPrefix file prefix = runForgeTest file (\(TestMethodInfo _ (Sig name _)) -> prefix `isPrefixOf` name)
 
-executeTestMethodsMatching :: (App m, MonadMask m) => FilePath -> Text -> m (Bool, Bool)
-executeTestMethodsMatching file matcher = runForgeTest file (\(TestMethodInfo _ (Sig name _)) -> regexMatches matcher name && "prove" `isPrefixOf` name)
+assertAllMethodsWithPrefix :: (App m, MonadMask m) => FilePath -> Text -> (Bool, Bool) -> m ()
+assertAllMethodsWithPrefix file prefix =
+  assertAllMethods file ("prefix: " <> unpack prefix) (\(TestMethodInfo _ (Sig name _)) -> prefix `isPrefixOf` name)
+
+assertAllTestMethodsMatching :: (App m, MonadMask m) => FilePath -> Text -> (Bool, Bool) -> m ()
+assertAllTestMethodsMatching file matcher =
+  assertAllMethods file ("regex: " <> unpack matcher) (\(TestMethodInfo _ (Sig name _)) -> regexMatches matcher name && "prove" `isPrefixOf` name)
+
+assertAllMethods :: (App m, MonadMask m) => FilePath -> String -> TestMethodFilter -> (Bool, Bool) -> m ()
+assertAllMethods file description methodFilter expected = do
+  results <- runForgeTestResults file methodFilter
+  liftIO $ assertBool ("no methods matching " <> description) (not $ null results)
+  assertEqualM "test results" (replicate (length results) expected) results

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -30,6 +30,14 @@ runForgeTestCustom
   :: (MonadMask m, App m)
   => FilePath -> TestMethodFilter -> Maybe Natural -> Maybe Integer -> Bool -> RpcInfo -> m (Bool, Bool)
 runForgeTestCustom testFile methodFilter timeout maxIter ffiAllowed rpcinfo = do
+  results <- runForgeTestResultsCustom testFile methodFilter timeout maxIter ffiAllowed rpcinfo
+  let (firsts, seconds) = unzip results
+  pure (and firsts, and seconds)
+
+runForgeTestResultsCustom
+  :: (MonadMask m, App m)
+  => FilePath -> TestMethodFilter -> Maybe Natural -> Maybe Integer -> Bool -> RpcInfo -> m [(Bool, Bool)]
+runForgeTestResultsCustom testFile methodFilter timeout maxIter ffiAllowed rpcinfo = do
   withSystemTempDirectory "dapp-test" $ \root -> do
     compileWithForge root testFile >>= \case
       Left e -> liftIO $ do
@@ -39,13 +47,18 @@ runForgeTestCustom testFile methodFilter timeout maxIter ffiAllowed rpcinfo = do
       Right buildOut -> do
         withSolvers Bitwuzla 3 timeout defMemLimit $ \solvers -> do
           opts <- testOpts solvers root (Just buildOut) methodFilter maxIter ffiAllowed rpcinfo
-          unitTest opts buildOut
+          unitTestResults opts buildOut
 
 -- Returns tuple of (No cex, No warnings)
 runForgeTest
   :: (MonadMask m, App m)
   => FilePath -> TestMethodFilter -> m (Bool, Bool)
 runForgeTest testFile methodFilter = runForgeTestCustom testFile methodFilter Nothing Nothing False noRpc
+
+runForgeTestResults
+  :: (MonadMask m, App m)
+  => FilePath -> TestMethodFilter -> m [(Bool, Bool)]
+runForgeTestResults testFile methodFilter = runForgeTestResultsCustom testFile methodFilter Nothing Nothing False noRpc
 
 testOpts :: forall m . App m => SolverGroup -> FilePath -> Maybe BuildOutput -> TestMethodFilter -> Maybe Integer -> Bool -> RpcInfo -> m (UnitTestOptions)
 testOpts solvers root buildOutput methodFilter maxIter allowFFI rpcinfo = do

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -81,8 +81,10 @@ tests = testGroup "rpc"
     [ test "dapp-test" $ do
         let testFile = "test/contracts/pass/rpc.sol"
         rpcInfo <- liftIO testRpcInfo
-        res <- runForgeTestCustom testFile (\(TestMethodInfo _ (Sig name _)) -> "prove" `isPrefixOf` name) Nothing Nothing False rpcInfo
-        liftIO $ assertEqual "test result" (True, True) res
+        results <- runForgeTestResultsCustom testFile (\(TestMethodInfo _ (Sig name _)) -> "prove" `isPrefixOf` name) Nothing Nothing False rpcInfo
+        liftIO $ do
+          assertBool "no methods matching prefix: prove" (not $ null results)
+          assertEqual "test results" (replicate (length results) (True, True)) results
 
     -- concretely exec "transfer" on WETH9 using remote rpc
     -- https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2#code


### PR DESCRIPTION
## Description

runForgeTest combines per-method outcomes with and. This is suitable for suite-level CLI reporting, but too weak for tests that expect every selected method to have a specific result. An aggregate False only proves that at least one method failed, while an empty selection yields (True, True).

Expose raw unit-test results to test helpers and assert non-empty, per-method outcomes for homogeneous regex and prefix selections. Use exact-name, single-result checks for individual and custom-option tests so similarly prefixed methods cannot affect results. Keep aggregate reduction only for the mixed-warning suite where it is intentional.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
