### PR TITLE
perf: make keccak preimage recording optional and strict

### DIFF
--- a/bench/bench-perf.hs
+++ b/bench/bench-perf.hs
@@ -31,7 +31,12 @@ vmFromRawByteString bs = liftIO $
     & initialContract
     & vm0
     & stToIO
-    & fmap EVM.Transaction.initTx
+    & fmap (noKeccakPreImgs . EVM.Transaction.initTx)
+
+-- keccak preimages are only consumed when symbolic execution follows from the
+-- state; these benchmarks are purely concrete, so skip the bookkeeping
+noKeccakPreImgs :: VM Concrete -> VM Concrete
+noKeccakPreImgs vm = vm { config = vm.config { recordKeccakPreImgs = False } }
 
 vm0 :: Contract -> ST RealWorld (VM Concrete)
 vm0 c = makeVm $ vm0Opts c

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -193,6 +193,7 @@ makeVm o = do
     , config = RuntimeConfig
       { allowFFI = o.allowFFI
       , baseState = o.baseState
+      , recordKeccakPreImgs = True
       }
     , forks = Seq.singleton (ForkState env block mempty "")
     , currentFork = 0
@@ -494,7 +495,8 @@ exec1 conf = do
                         (pure $ Keccak orig)
                         (do
                           let kc = keccak' bs
-                          modifying #keccakPreImgs (insert (bs, kc))
+                          when vm.config.recordKeccakPreImgs $
+                            modifying' #keccakPreImgs (insert (bs, kc))
                           pure $ Lit kc
                         )
                     buf -> pure $ Keccak buf

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -780,6 +780,7 @@ runSrcLookup (Just (SrcLookup f)) contracts addr pc = f contracts addr pc
 data RuntimeConfig = RuntimeConfig
   { allowFFI :: Bool
   , baseState :: BaseState
+  , recordKeccakPreImgs :: Bool
   }
   deriving (Show)
 


### PR DESCRIPTION
## Description

Concrete Keccak recorded every preimage in vm.keccakPreImgs with a lazy modifying, building an unforced chain of Set inserts that retains every hashed buffer for the VM's lifetime. The set is only consumed when symbolic execution continues from the state (keccak constraints for the solver), so purely concrete users pay for nothing they use.

Gate the recording behind RuntimeConfig.recordKeccakPreImgs (default True, preserving existing behavior) and force the insert when it does happen.

Benchmark: Echidna fuzzing a real-world Foundry project (1 workers, 15k calls plus corpus replay) with this commit and the consumer setting the flag to False: GC time 2.89s -> 2.02s, bytes copied during GC -1.8 GB, mutator time -0.4s.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
