### PR TITLE
Work around libff missing headers with CMake 4.3 in Echidna CI

### DIFF
--- a/.github/workflows/echidna-compat.yml
+++ b/.github/workflows/echidna-compat.yml
@@ -67,10 +67,12 @@ jobs:
         run: |
           # --fast skips optimizations since we only
           # care about compilation, not runtime perf.
+          # libff override: https://github.com/NixOS/nixpkgs/pull/559966
           nix-shell \
             -I nixpkgs=channel:nixpkgs-unstable \
-            -p secp256k1 libff gmp ncurses zlib pkg-config stack \
+            -p secp256k1 gmp ncurses zlib pkg-config stack \
                'haskell.compiler.ghc984' \
+               "libff.overrideAttrs (o: { postPatch = o.postPatch + ''substituteInPlace libff/CMakeLists.txt --replace-warn 'DIRECTORY \"\"' 'DIRECTORY \"./\"' ''; })" \
             --run 'stack build --fast \
               --test --no-run-tests \
               --system-ghc --skip-ghc-check &&


### PR DESCRIPTION


## Description
CMake 4.3 changed install(DIRECTORY "" ...) from "install the current source directory" to a no-op, so the libff package on the nixpkgs-unstable channel (cmake 4.3.4) installs no headers and hevm's ethjet-ff.cc cannot compile in the Echidna compatibility job.

Override libff in the nix-shell with the postPatch from https://github.com/NixOS/nixpkgs/pull/559966 until that fix reaches the channel. --replace-warn (rather than the PR's --replace-fail) keeps the job green once the upstream fix lands and the pattern disappears; the override can then be dropped.

See https://gitlab.kitware.com/cmake/cmake/-/issues/27568
## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
